### PR TITLE
Add Speedoodle site, deployment config, and license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+node_modules/
+dist/
+.vercel/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Speedoodle 🚀 — בדיקת מהירות אינטרנט
+
+אתר קטן בסגנון Fast.com לבדיקת מהירות (הורדה, העלאה ופינג) מול Cloudflare.
+
+## הרצה מקומית
+```bash
+npx serve .
+# או
+python3 -m http.server 9000
+```
+ואז לפתוח את [http://localhost:9000](http://localhost:9000)
+
+## פריסה ל-Vercel
+1. היכנס ל-[Vercel](https://vercel.com) → Import Project
+2. בחר את הריפו `speedoodle`
+3. Framework = **Other**
+4. Build Command = ריק
+5. Output Directory = `.`
+6. Deploy 🚀
+
+## חיבור דומיין
+- הוסף את `speedoodle.com` תחת Settings → Domains ב-Vercel
+- ב-DNS של הדומיין:
+  - רשומת A ל-`76.76.21.21`
+  - רשומת CNAME (www) ל-`cname.vercel-dns.com`
+

--- a/index.html
+++ b/index.html
@@ -1,1 +1,64 @@
-<!doctype html><meta charset="utf-8"><title>Speedoodle</title>Hello
+<!doctype html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Speedoodle 🚀 — בדיקת מהירות אינטרנט</title>
+  <meta name="description" content="Speedoodle 🚀 — בדיקת מהירות הורדה, העלאה ופינג בזמן אמת." />
+  <style>
+    body {
+      margin: 0; font-family: system-ui, sans-serif;
+      background: linear-gradient(135deg, #0f172a, #1e3a8a); color: #fff;
+      display: flex; justify-content: center; align-items: center; height: 100vh;
+    }
+    .card { background: rgba(255,255,255,0.08); padding: 24px; border-radius: 16px; text-align:center; width: 90%; max-width: 480px; backdrop-filter: blur(10px); }
+    .logo { font-size: 42px; font-weight: 800; display:flex; justify-content:center; gap:10px; }
+    .sub { margin-top: 6px; color: #cbd5e1; }
+    .big { font-size: clamp(72px, 16vw, 180px); font-weight:900; line-height:.9; margin-top:12px; text-shadow:0 2px 0 #fff, 0 20px 60px rgba(14,165,233,0.35); }
+    .unit { font-size: 28px; margin-inline-start: 8px; }
+    .row { display:flex; justify-content:center; align-items:flex-end; }
+    .kpis { display:grid; grid-template-columns:1fr 1fr; gap:12px; margin-top:20px; }
+    .kpi { background: rgba(0,0,0,0.3); padding:12px; border-radius:12px; }
+    .kpi h4 { margin:0 0 6px; font-size:16px; }
+    .kpi .val { font-size:22px; font-weight:700; }
+    .status { margin-top: 14px; color:#94a3b8; }
+    .btns { margin-top:16px; display:flex; gap:12px; justify-content:center; }
+    .btn { padding:10px 18px; border-radius:10px; background:#1e3a8a; color:white; border:1px solid #38bdf8; font-weight:600; cursor:pointer; }
+    .btn-danger { background:#b91c1c; border-color:#ef4444; }
+    .adbar { position:fixed; left:0; right:0; bottom:0; background:#000000cc; color:#ccc; display:flex; justify-content:center; padding:10px; }
+    .adslot { width:min(970px,92vw); height:60px; border:1px dashed #94a3b8; display:flex; align-items:center; justify-content:center; }
+  </style>
+</head>
+<body>
+  <section class="card">
+    <div class="logo">🚀 <span>Speedoodle</span></div>
+    <div class="sub">מהירות האינטרנט שלך היא</div>
+    <div class="row"><div id="big" class="big">0.0</div><div class="unit">Mbps</div></div>
+    <div id="avgpeak" class="sub">ממוצע: 0.0 Mbps | שיא: 0.0 Mbps</div>
+    <div class="kpis">
+      <div class="kpi"><h4>השהיה</h4><div class="val" id="lat">– ms</div></div>
+      <div class="kpi"><h4>העלאה</h4><div class="val" id="up">–</div></div>
+    </div>
+    <div id="status" class="status">מוכן</div>
+    <div class="btns">
+      <button id="start" class="btn">התחל בדיקה</button>
+      <button id="stop" class="btn btn-danger" style="display:none">עצור</button>
+    </div>
+  </section>
+  <div class="adbar"><div class="adslot">מקום למודעה (Ad Banner)</div></div>
+  <script>
+    const CF_BASE = "https://speed.cloudflare.com";
+    const big=document.getElementById("big"),avgpeak=document.getElementById("avgpeak"),latEl=document.getElementById("lat"),upEl=document.getElementById("up"),statusEl=document.getElementById("status"),startBtn=document.getElementById("start"),stopBtn=document.getElementById("stop");
+    const PARALLEL_STREAMS=6,DL_DURATION_MS=8000,UL_DURATION_MS=6000,WARMUP_MS=2000,WINDOW_MS=2000,CHUNK_BYTES_DL=5*1024*1024,CHUNK_BYTES_UP=256*1024;
+    function humanMbps(b){return (!b||!isFinite(b))?"0.0":(b/1048576).toFixed(1)}
+    function formatMs(v){return Number.isFinite(v)?v.toFixed(0):"–"}
+    async function measureLatency(base,a=3){const l=[];for(let i=0;i<a;i++){const u=`${base}/__down?bytes=1&ts=${Math.random()}`,t0=performance.now();try{const r=await fetch(u,{cache:"no-store"});if(!r.ok)throw new Error();const t1=performance.now();l.push(t1-t0)}catch{l.push(9999)}}return l.reduce((s,x)=>s+x,0)/l.length}
+    async function downloadTest(base,cancel){let rec=0;const start=performance.now(),stopAt=start+DL_DURATION_MS,warm=start+WARMUP_MS,samples=[];let peak=0;async function one(){while(performance.now()<stopAt&&!cancel()){const url=`${base}/__down?bytes=${CHUNK_BYTES_DL}&ts=${Math.random()}`,r=await fetch(url,{cache:"no-store"});if(!r.ok||!r.body)break;const reader=r.body.getReader();while(true){const {done,value}=await reader.read();if(done)break;rec+=value.byteLength;const now=performance.now();samples.push({t:now,bytes:value.byteLength});while(samples.length&&samples[0].t<now-WINDOW_MS)samples.shift();if(now>warm){const bps=samples.reduce((s,x)=>s+x.bytes,0)*8/(WINDOW_MS/1000);if(bps>peak)peak=bps}}if(performance.now()+80>stopAt)break}}await Promise.allSettled(Array.from({length:PARALLEL_STREAMS},one));const eff=Math.min(warm,stopAt),secs=Math.max(.001,(Math.min(performance.now(),stopAt)-eff)/1000);return{avgBps:(rec*8)/secs,peakBps:peak}}
+    async function uploadTest(base,cancel){let sent=0;const stopAt=performance.now()+UL_DURATION_MS,payload=new Uint8Array(CHUNK_BYTES_UP);async function one(){while(performance.now()<stopAt&&!cancel()){const r=await fetch(`${base}/__up?ts=${Math.random()}`,{method:"POST",body:payload,cache:"no-store"});if(!r.ok)break;sent+=payload.byteLength;if(performance.now()+50>stopAt)break}}await Promise.allSettled(Array.from({length:PARALLEL_STREAMS},one));return{bitsPerSec:(sent*8)/(UL_DURATION_MS/1000)}}
+    let cancelled=false;function isCancelled(){return cancelled}
+    async function run(){if(startBtn.disabled)return;cancelled=false;startBtn.disabled=true;stopBtn.style.display="inline-block";statusEl.textContent="בודק השהיה…";big.textContent="0.0";avgpeak.textContent="ממוצע: 0.0 Mbps | שיא: 0.0 Mbps";latEl.textContent="– ms";upEl.textContent="–";
+      try{const lat=await measureLatency(CF_BASE,3);latEl.textContent=`${formatMs(lat)} ms`;statusEl.textContent="מודד הורדה…";const dl=await downloadTest(CF_BASE,isCancelled);const peak=Number(humanMbps(dl.peakBps)),avg=Number(humanMbps(dl.avgBps));big.textContent=peak.toFixed(1);avgpeak.textContent=`ממוצע: ${avg.toFixed(1)} Mbps | שיא: ${peak.toFixed(1)} Mbps`;statusEl.textContent="מודד העלאה…";const up=await uploadTest(CF_BASE,isCancelled);upEl.textContent=`${Number(humanMbps(up.bitsPerSec)).toFixed(1)} Mbps`;statusEl.textContent=cancelled?"בוטל":"סיום"}catch(e){statusEl.textContent="שגיאה"}finally{startBtn.disabled=false;stopBtn.style.display="none"}}
+    startBtn.addEventListener("click",run);stopBtn.addEventListener("click",()=>{cancelled=true;statusEl.textContent="בוטל"});
+  </script>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
## Summary
- Replace placeholder with full Hebrew Speedoodle page and Cloudflare-based speed test
- Expand README with local run, Vercel deployment, and domain setup instructions
- Add Vercel config, ignore list, and MIT license

## Testing
- `python3 -m http.server 9000 >/tmp/server.log 2>&1 &
server_pid=$!
sleep 1
curl -I http://localhost:9000/index.html
kill $server_pid`

------
https://chatgpt.com/codex/tasks/task_e_68c6f7aa6cd88323838ee46a6fe39838