### PR TITLE
Add robots.txt with sitemap

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://speedoodle.vercel.app/sitemap.xml


### PR DESCRIPTION
## Summary
- add robots.txt to allow all crawlers and point to sitemap

## Testing
- `npm test` (fails: enoent package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c704ba69f883238d3ba519e141e37b