### PR TITLE
translate legal & info pages to English (LTR)

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,18 +1,18 @@
-<!doctype html><html lang="he" dir="rtl"><head>
+<!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>אודות | Speedoodle 🚀</title>
+<title>About | Speedoodle 🚀</title>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">
-<h1>אודות</h1>
-<p>Speedoodle הוא כלי קליל לבדיקת מהירות אינטרנט בסגנון Fast.com – פשוט, מהיר ונעים.</p>
+<h1>About</h1>
+<p>Speedoodle is a lightweight internet speed test inspired by Fast.com—simple, fast, and friendly.</p>
 <ul>
-  <li>פשטות: תוצאה ברורה של מהירות ההורדה/העלאה והשהיה.</li>
-  <li>פרטיות: מינימום איסוף נתונים הנחוץ להפעלת האתר.</li>
-  <li>זמינות: אירוח ב-Vercel עם זמני טעינה מהירים.</li>
+  <li>Simplicity: clear download/upload/latency results.</li>
+  <li>Privacy: minimal data collection to run the site.</li>
+  <li>Availability: hosted on Vercel for quick loads.</li>
 </ul>
-<p>יש הצעות לשיפור? נשמח לשמוע: <a href="mailto:hello@speedoodle.com">hello@speedoodle.com</a></p>
+<p>Suggestions? <a href="mailto:hello@speedoodle.com">hello@speedoodle.com</a></p>
 </main>
-<footer><a href="privacy.html">פרטיות</a> · <a href="terms.html">תנאים</a> · <a href="about.html">אודות</a> · <a href="contact.html">צור קשר</a></footer>
+<footer><a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a> · <a href="about.html">About</a> · <a href="contact.html">Contact</a></footer>
 </body></html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,19 @@
+<!doctype html><html lang="en" dir="ltr"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Contact | Speedoodle 🚀</title>
+<link rel="stylesheet" href="site.css">
+</head><body>
+<header><a href="./">Speedoodle 🚀</a></header>
+<main class="container">
+<h1>Contact</h1>
+<p>We’d love to hear from you.</p>
+<form action="mailto:hello@speedoodle.com" method="post" enctype="text/plain" class="card">
+  <label>Full name<input name="name" required></label>
+  <label>Email<input type="email" name="email" required></label>
+  <label>Message<textarea name="message" rows="5" required></textarea></label>
+  <button type="submit">Send</button>
+</form>
+<p>You can switch to a form service later (e.g., Formspree).</p>
+</main>
+<footer><a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a> · <a href="about.html">About</a> · <a href="contact.html">Contact</a></footer>
+</body></html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,43 +1,35 @@
-<!doctype html><html lang="he" dir="rtl"><head>
+<!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>מדיניות פרטיות | Speedoodle 🚀</title>
+<title>Privacy Policy | Speedoodle 🚀</title>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">
-<h1>מדיניות פרטיות</h1>
-<p>עודכן: 2025-09-14</p>
-
-<p>ברוכים הבאים ל-Speedoodle (“האתר”). אנו מכבדים את פרטיות המשתמשים. מסמך זה מסביר אילו נתונים נאספים, כיצד אנו משתמשים בהם ומהן הזכויות שלך.</p>
-
-<h2>איזה מידע אנו אוספים?</h2>
+<h1>Privacy Policy</h1>
+<p>Updated: 2025-09-14</p>
+<p>Welcome to Speedoodle (“the Site”). We respect your privacy. This policy explains what data we collect, how we use it, and your rights.</p>
+<h2>What we collect</h2>
 <ul>
-  <li><strong>מידע טכני</strong>: כתובת IP אנונימית/מקוצרה, סוג דפדפן, שפה, דפי הפניה וסטטיסטיקות שימוש בסיסיות.</li>
-  <li><strong>עוגיות (Cookies)</strong>: לקסטומיזציה בסיסית ומדידות. ניתן לחסום דרך הגדרות הדפדפן.</li>
-  <li><strong>טפסי קשר</strong>: שם, אימייל ותוכן הודעה – רק אם מילאת בטופס <a href="contact.html">צור קשר</a>.</li>
+  <li><strong>Technical data</strong>: truncated/anonymous IP, browser type, language, referrers, basic usage stats.</li>
+  <li><strong>Cookies</strong>: for basic customization and measurement. You can block cookies in your browser.</li>
+  <li><strong>Contact forms</strong>: name, email, and message—only if you submit the <a href="contact.html">contact form</a>.</li>
 </ul>
-
-<h2>שימוש במידע</h2>
+<h2>How we use data</h2>
 <ul>
-  <li>שיפור האתר, אבטחה וסטטיסטיקות.</li>
-  <li>מענה לפניות ששלחת.</li>
-  <li>פרסום (למשל Google AdSense) אם יופעל בעתיד. ספקי פרסום עשויים להשתמש בעוגיות/מזהים לצורך הצגת מודעות מותאמות.</li>
+  <li>To improve the site, security, and analytics.</li>
+  <li>To respond to your messages.</li>
+  <li>Advertising (e.g., Google AdSense) if enabled later. Ad providers may use cookies/IDs for personalized ads.</li>
 </ul>
-
-<h2>שיתופים</h2>
-<p>איננו מוכרים מידע אישי. ייתכנו שיתופים עם ספקי תשתית (אחסון, ניתוח תעבורה, פרסום) בכפוף להסכמים מחייבים.</p>
-
-<h2>זכויות משתמש</h2>
-<p>תוכל לבקש גישה/מחיקה של מידע שנמסר דרך הטופס. פנה אלינו ב-<a href="mailto:hello@speedoodle.com">hello@speedoodle.com</a>. אם אין לך דומיין, החלף לאימייל הפעיל שלך.</p>
-
-<h2>קטינים</h2>
-<p>האתר מיועד לבני 16+.</p>
-
-<h2>אבטחה</h2>
-<p>נוקטים באמצעים סבירים להגנה על מידע, אך אין אבטחה מוחלטת.</p>
-
-<h2>עדכונים</h2>
-<p>יתכנו שינויים במסמך זה. המשך שימושך באתר מהווה הסכמה למדיניות המעודכנת.</p>
+<h2>Sharing</h2>
+<p>We do not sell personal data. We may share with infrastructure/analytics/ads providers under binding agreements.</p>
+<h2>Your rights</h2>
+<p>You can request access/deletion of data submitted via the form. Contact: <a href="mailto:hello@speedoodle.com">hello@speedoodle.com</a>.</p>
+<h2>Children</h2>
+<p>The site is intended for users aged 16+.</p>
+<h2>Security</h2>
+<p>We take reasonable measures to protect data, but no method is 100% secure.</p>
+<h2>Changes</h2>
+<p>We may update this policy. Continued use constitutes acceptance of the updated policy.</p>
 </main>
-<footer><a href="privacy.html">פרטיות</a> · <a href="terms.html">תנאים</a> · <a href="about.html">אודות</a> · <a href="contact.html">צור קשר</a></footer>
+<footer><a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a> · <a href="about.html">About</a> · <a href="contact.html">Contact</a></footer>
 </body></html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,29 @@
+<!doctype html><html lang="en" dir="ltr"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Terms of Use | Speedoodle 🚀</title>
+<link rel="stylesheet" href="site.css">
+</head><body>
+<header><a href="./">Speedoodle 🚀</a></header>
+<main class="container">
+<h1>Terms of Use</h1>
+<p>Updated: 2025-09-14</p>
+<h2>Using the Site</h2>
+<ul>
+  <li>Speedoodle provides an internet speed test for informational purposes only. Results are not a guarantee of your ISP performance.</li>
+  <li>Do not abuse the service, perform aggressive scraping, bypass protections, or disrupt the site.</li>
+</ul>
+<h2>Intellectual Property</h2>
+<p>All content/UI/design—unless stated otherwise—belong to Speedoodle. No copying without permission.</p>
+<h2>Disclaimer</h2>
+<p>The site is provided “AS IS” without warranties to the fullest extent permitted by law.</p>
+<h2>Limitation of Liability</h2>
+<p>We are not liable for indirect/consequential damages resulting from the use of the site.</p>
+<h2>Privacy</h2>
+<p>See our <a href="privacy.html">Privacy Policy</a>.</p>
+<h2>Changes</h2>
+<p>We may update these terms; continued use constitutes acceptance.</p>
+<h2>Contact</h2>
+<p><a href="mailto:hello@speedoodle.com">hello@speedoodle.com</a></p>
+</main>
+<footer><a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a> · <a href="about.html">About</a> · <a href="contact.html">Contact</a></footer>
+</body></html>


### PR DESCRIPTION
## Summary
- Rewrote Privacy Policy, Terms, About, and Contact pages in English with left-to-right layout and English navigation links.
- Added English contact form page.
- Ensured sitemap uses the speedoodle.vercel.app domain for all URLs.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7203a6a248323982362a50fd11814