### PR TITLE
Add AdSense verification script to all HTML pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,6 +2,9 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>About | Speedoodle 🚀</title>
 <link rel="stylesheet" href="site.css">
+<!-- AdSense verification -->
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519"
+     crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,9 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Contact | Speedoodle 🚀</title>
 <link rel="stylesheet" href="site.css">
+<!-- AdSense verification -->
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519"
+     crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">

--- a/index.html
+++ b/index.html
@@ -29,6 +29,9 @@
     .adbar { position:fixed; left:0; right:0; bottom:0; background:#000000cc; color:#ccc; display:flex; justify-content:center; padding:10px; }
     .adslot { width:min(970px,92vw); height:60px; border:1px dashed #94a3b8; display:flex; align-items:center; justify-content:center; }
   </style>
+<!-- AdSense verification -->
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519"
+     crossorigin="anonymous"></script>
 </head>
 <body>
   <section class="card">

--- a/privacy.html
+++ b/privacy.html
@@ -2,6 +2,9 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Privacy Policy | Speedoodle 🚀</title>
 <link rel="stylesheet" href="site.css">
+<!-- AdSense verification -->
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519"
+     crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">

--- a/terms.html
+++ b/terms.html
@@ -2,6 +2,9 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Terms of Use | Speedoodle 🚀</title>
 <link rel="stylesheet" href="site.css">
+<!-- AdSense verification -->
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519"
+     crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">


### PR DESCRIPTION
## Summary
- insert AdSense verification script before `</head>` on index and content pages

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c7d8f8a0a88323a2f3266643e9ec12