### PR TITLE
Domain migration: use speedoodle.com (canonical, sitemap, robots, redirects, ads.txt)

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,6 +1,7 @@
 <!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>About | Speedoodle 🚀</title>
+<link rel="canonical" href="https://speedoodle.com/about.html">
 <link rel="stylesheet" href="site.css">
 <!-- AdSense verification -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519"

--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-8054613411767519, DIRECT, f08c47fec0942fa0

--- a/contact.html
+++ b/contact.html
@@ -1,6 +1,7 @@
 <!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Contact | Speedoodle 🚀</title>
+<link rel="canonical" href="https://speedoodle.com/contact.html">
 <link rel="stylesheet" href="site.css">
 <!-- AdSense verification -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519"

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Speedoodle 🚀 — Internet Speed Test</title>
   <meta name="description" content="Speedoodle 🚀 — test your download, upload, and ping in real-time." />
+  <link rel="canonical" href="https://speedoodle.com/" />
   <link rel="stylesheet" href="style.css" />
   <style>
     body {

--- a/privacy.html
+++ b/privacy.html
@@ -1,6 +1,7 @@
 <!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Privacy Policy | Speedoodle 🚀</title>
+<link rel="canonical" href="https://speedoodle.com/privacy.html">
 <link rel="stylesheet" href="site.css">
 <!-- AdSense verification -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519"

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
-Sitemap: https://speedoodle.vercel.app/sitemap.xml
+
+Sitemap: https://speedoodle.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://speedoodle.vercel.app/</loc></url>
-  <url><loc>https://speedoodle.vercel.app/privacy.html</loc></url>
-  <url><loc>https://speedoodle.vercel.app/terms.html</loc></url>
-  <url><loc>https://speedoodle.vercel.app/about.html</loc></url>
-  <url><loc>https://speedoodle.vercel.app/contact.html</loc></url>
+  <url><loc>https://speedoodle.com/</loc></url>
+  <url><loc>https://speedoodle.com/privacy.html</loc></url>
+  <url><loc>https://speedoodle.com/terms.html</loc></url>
+  <url><loc>https://speedoodle.com/about.html</loc></url>
+  <url><loc>https://speedoodle.com/contact.html</loc></url>
 </urlset>

--- a/terms.html
+++ b/terms.html
@@ -1,6 +1,7 @@
 <!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Terms of Use | Speedoodle 🚀</title>
+<link rel="canonical" href="https://speedoodle.com/terms.html">
 <link rel="stylesheet" href="site.css">
 <!-- AdSense verification -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519"

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,16 @@
 {
-  "cleanUrls": true
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.speedoodle.com" }],
+      "destination": "https://speedoodle.com/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "speedoodle.vercel.app" }],
+      "destination": "https://speedoodle.com/:path*",
+      "permanent": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add canonical tags pointing to speedoodle.com on all pages
- update sitemap and robots.txt for new apex domain
- add ads.txt and configure vercel redirects to enforce https/apex

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e0d2f52483239b00987994b6435c