### PR TITLE
Add AdSense site verification meta tag

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,5 +1,6 @@
 <!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <title>About | Speedoodle 🚀</title>
 <link rel="canonical" href="https://speedoodle.com/about.html">
 <link rel="stylesheet" href="site.css">

--- a/contact.html
+++ b/contact.html
@@ -1,5 +1,6 @@
 <!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <title>Contact | Speedoodle 🚀</title>
 <link rel="canonical" href="https://speedoodle.com/contact.html">
 <link rel="stylesheet" href="site.css">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="google-adsense-account" content="ca-pub-8054613417167519">
   <title>Speedoodle 🚀 — Internet Speed Test</title>
   <meta name="description" content="Speedoodle 🚀 — test your download, upload, and ping in real-time." />
   <link rel="canonical" href="https://speedoodle.com/" />

--- a/privacy.html
+++ b/privacy.html
@@ -1,5 +1,6 @@
 <!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <title>Privacy Policy | Speedoodle 🚀</title>
 <link rel="canonical" href="https://speedoodle.com/privacy.html">
 <link rel="stylesheet" href="site.css">

--- a/terms.html
+++ b/terms.html
@@ -1,5 +1,6 @@
 <!doctype html><html lang="en" dir="ltr"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <title>Terms of Use | Speedoodle 🚀</title>
 <link rel="canonical" href="https://speedoodle.com/terms.html">
 <link rel="stylesheet" href="site.css">


### PR DESCRIPTION
## Summary
- add google-adsense-account meta tag across all html pages for AdSense site verification

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c7e40a1ed08323a19f490119f40fe5