### PR TITLE
Add AdSense meta tag to HTML pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,6 +15,7 @@
 <meta name="twitter:description" content="Learn about Speedoodle, the lightweight internet speed test.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
+<meta name="google-adsense-account" content="ca-pub-8054613411767519">
 <!-- AdSense verification -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
 </head><body>

--- a/contact.html
+++ b/contact.html
@@ -15,6 +15,7 @@
 <meta name="twitter:description" content="Contact the Speedoodle team with questions or feedback.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
+<meta name="google-adsense-account" content="ca-pub-8054613411767519">
 <!-- AdSense verification -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
 </head><body>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 <meta name="twitter:description" content="Fast, accurate speed test for download/upload/ping.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
+<meta name="google-adsense-account" content="ca-pub-8054613411767519">
 <!-- AdSense verification -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
 <style>

--- a/privacy.html
+++ b/privacy.html
@@ -15,6 +15,7 @@
 <meta name="twitter:description" content="Learn how Speedoodle handles your data and privacy.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
+<meta name="google-adsense-account" content="ca-pub-8054613411767519">
 <!-- AdSense verification -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
 </head><body>

--- a/terms.html
+++ b/terms.html
@@ -15,6 +15,7 @@
 <meta name="twitter:description" content="Terms of use for the Speedoodle internet speed test site.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
+<meta name="google-adsense-account" content="ca-pub-8054613411767519">
 <!-- AdSense verification -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
 </head><body>


### PR DESCRIPTION
## Summary
- reintroduce the AdSense verification meta tag on about, contact, index, privacy, and terms pages

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e74eb60483239848dd6f41213438