### PR TITLE
Add status indicator for speed test

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,10 +34,10 @@
       <div class="stat"><div class="label">Latency</div><div class="value"><span id="pg">—</span> ms</div></div>
       <div class="stat"><div class="label">Upload</div><div class="value"><span id="ul">—</span> Mbps</div></div>
     </div>
-    <div id="status" class="muted" style="margin:12px 0">Ready</div>
     <button id="runTest">Start Test</button>
   </div>
 </section>
+<div id="status" class="muted" aria-live="polite" style="margin:12px 0">Ready</div>
 <div id="ad1">
   <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8054613411767519" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
   <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
@@ -90,7 +90,11 @@ function startUI(){
                          ul.to(Math.min(ul.value + Math.random()*8+2, 150), 500);
                          pg.to(Math.max(5, pg.value + (Math.random()*10 - 3)), 400); }, 800);
 }
-function stopUI(){ clearInterval(ramp); body.classList.remove('testing'); statusEl.textContent='Done'; }
+function stopUI(message='Done'){
+  clearInterval(ramp);
+  body.classList.remove('testing');
+  statusEl.textContent = message;
+}
 // Hook your real tester here. Keep stub if none exists.
 async function runSpeedTest({onProgress}={}){
   const CF_BASE = "https://speed.cloudflare.com";
@@ -166,8 +170,10 @@ document.getElementById('runTest')?.addEventListener('click', async ()=>{
     });
     dl.to(final.downloadMbps,900); ul.to(final.uploadMbps,900); pg.to(final.pingMs,700);
     const avg=document.getElementById('avg'); if(avg) avg.textContent=`Average: ${final.avg?.toFixed?final.avg.toFixed(1):final.avg||dl.value.toFixed(1)} Mbps | Peak: ${final.peak||Math.max(dl.value,250)} Mbps`;
-  } catch(e){ statusEl.textContent='Error running test'; }
-  finally{ stopUI(); }
+    stopUI();
+  } catch(e){
+    stopUI('Error running test');
+  }
 });
 // Optional: auto-start on load
 // document.getElementById('runTest')?.click();


### PR DESCRIPTION
## Summary
- show live status updates after the results panel
- update UI helpers to announce "Testing" and "Done" messages

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ee60de548323945108ce35ebc340