### PR TITLE
ci: auto-merge PRs (label or codex/* branches)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,29 @@
+name: Auto-merge
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'automerge')
+      || startsWith(github.event.pull_request.head.ref, 'codex/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for checks
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+          allowed-conclusions: success
+      - name: Enable & merge (squash)
+        uses: pascalgn/automerge-action@v0.16.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_METHOD: squash
+          MERGE_DELETE_BRANCH: "true"
+          MERGE_RETRIES: "24"
+          MERGE_RETRY_SLEEP: "15s"
+          # will only merge when all required checks are green and reviews (if required) are satisfied

--- a/.github/workflows/label-codex-prs.yml
+++ b/.github/workflows/label-codex-prs.yml
@@ -1,0 +1,16 @@
+name: Label Codex PRs
+on:
+  pull_request_target:
+    types: [opened, reopened]
+permissions:
+  pull-requests: write
+jobs:
+  label:
+    if: startsWith(github.event.pull_request.head.ref, 'codex/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add automerge label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: automerge


### PR DESCRIPTION
## Summary
- auto-merge workflow for PRs labeled `automerge` or from `codex/*` branches after checks pass
- label `codex/*` PRs with `automerge`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f872f2d4832392c199e606928ed4