### PR TITLE
Revert CSS cache-busting to restore previous design

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <title>About | Speedoodle</title>
 <meta name="description" content="Learn about Speedoodle, the lightweight internet speed test.">
 <link rel="canonical" href="https://speedoodle.com/about.html">
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Speedoodle">
 <meta property="og:title" content="About | Speedoodle">

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <title>Contact | Speedoodle</title>
 <meta name="description" content="Contact the Speedoodle team with questions or feedback.">
 <link rel="canonical" href="https://speedoodle.com/contact.html">
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Speedoodle">
 <meta property="og:title" content="Contact | Speedoodle">

--- a/embed/index.html
+++ b/embed/index.html
@@ -3,7 +3,7 @@
 <title>Embed Speed Test Widget | Speedoodle</title>
 <meta name="description" content="Embed a mini internet speed test widget on your site with a simple iframe.">
 <link rel="canonical" href="https://speedoodle.com/embed/">
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 </head><body>
 <header><a href="../">Speedoodle 🚀</a></header>
 <main class="container">

--- a/embed/mini.html
+++ b/embed/mini.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Speedoodle Mini</title>
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 <style>body{margin:0;font:14px system-ui,Arial,sans-serif}.box{padding:10px;border:1px solid #9993;border-radius:10px;margin:8px}</style>
 </head><body>
 <div class="box">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <title>Internet Speed Test | Speedoodle</title>
 <meta name="description" content="Run a fast, accurate internet speed test for download, upload, and ping. Mobile-friendly and privacy-first.">
 <link rel="canonical" href="https://speedoodle.com/">
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Speedoodle">
 <meta property="og:title" content="Internet Speed Test | Speedoodle">

--- a/isp-speed-test.html
+++ b/isp-speed-test.html
@@ -3,7 +3,7 @@
 <title>ISP Speed Test Differences | Speedoodle</title>
 <meta name="description" content="Understand why your ISP app shows different results vs independent tests.">
 <link rel="canonical" href="https://speedoodle.com/isp-speed-test.html">
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 <meta property="og:title" content="ISP Speed Test Differences | Speedoodle">
 <meta property="og:description" content="Why results differ between your ISP app and independent tests.">
 <meta property="og:url" content="https://speedoodle.com/isp-speed-test.html">

--- a/mobile-speed-test.html
+++ b/mobile-speed-test.html
@@ -3,7 +3,7 @@
 <title>Mobile Speed Test | Speedoodle</title>
 <meta name="description" content="Quick mobile speed test for download, upload, and ping. Optimized for phones—no app needed.">
 <link rel="canonical" href="https://speedoodle.com/mobile-speed-test.html">
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 <meta property="og:title" content="Mobile Speed Test | Speedoodle">
 <meta property="og:description" content="Quick mobile speed test for download, upload, and ping. No installs.">
 <meta property="og:url" content="https://speedoodle.com/mobile-speed-test.html">

--- a/ping-test.html
+++ b/ping-test.html
@@ -3,7 +3,7 @@
 <title>Ping Test | Speedoodle</title>
 <meta name="description" content="Quick ping test to measure latency for gaming and video calls.">
 <link rel="canonical" href="https://speedoodle.com/ping-test.html">
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 <meta property="og:title" content="Ping Test | Speedoodle">
 <meta property="og:description" content="Measure network latency for gaming, calls, and streaming.">
 <meta property="og:url" content="https://speedoodle.com/ping-test.html">

--- a/privacy.html
+++ b/privacy.html
@@ -3,7 +3,7 @@
 <title>Privacy Policy | Speedoodle</title>
 <meta name="description" content="Learn how Speedoodle handles your data and privacy.">
 <link rel="canonical" href="https://speedoodle.com/privacy.html">
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Speedoodle">
 <meta property="og:title" content="Privacy Policy | Speedoodle">

--- a/terms.html
+++ b/terms.html
@@ -3,7 +3,7 @@
 <title>Terms of Use | Speedoodle</title>
 <meta name="description" content="Terms of use for the Speedoodle internet speed test site.">
 <link rel="canonical" href="https://speedoodle.com/terms.html">
-<link rel="stylesheet" href="/site.css?v=4">
+<link rel="stylesheet" href="/site.css">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Speedoodle">
 <meta property="og:title" content="Terms of Use | Speedoodle">


### PR DESCRIPTION
## Summary
- Revert merge that added `?v=4` cache-busting query to `site.css` links
- Restore HTML pages to reference `/site.css` directly for previous design

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c80c3416cc83238444bed70e703a77