### PR TITLE
Fix AdSense account ID and ensure meta tags on speed test pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,9 +15,9 @@
 <meta name="twitter:description" content="Learn about Speedoodle, the lightweight internet speed test.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
-<meta name="google-adsense-account" content="ca-pub-8054613411767519">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <!-- AdSense verification -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">

--- a/ads.txt
+++ b/ads.txt
@@ -1,1 +1,1 @@
-google.com, pub-8054613411767519, DIRECT, f08c47fec0942fa0
+google.com, pub-8054613417167519, DIRECT, f08c47fec0942fa0

--- a/contact.html
+++ b/contact.html
@@ -15,9 +15,9 @@
 <meta name="twitter:description" content="Contact the Speedoodle team with questions or feedback.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
-<meta name="google-adsense-account" content="ca-pub-8054613411767519">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <!-- AdSense verification -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
 <meta name="twitter:description" content="Fast, accurate speed test for download/upload/ping.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
-<meta name="google-adsense-account" content="ca-pub-8054613411767519">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <!-- AdSense verification -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main>
@@ -39,7 +39,7 @@
 </section>
 <div id="status" class="muted" aria-live="polite" style="margin:12px 0">Ready</div>
 <div id="ad1">
-  <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8054613411767519" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
+  <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8054613417167519" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
   <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
 </div>
 <script>

--- a/isp-speed-test.html
+++ b/isp-speed-test.html
@@ -10,7 +10,8 @@
 <meta property="og:image" content="https://speedoodle.com/og.png">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">
@@ -19,7 +20,7 @@
   <h2>How to compare fairly</h2>
   <ul><li>Use the same device, location, and time.</li><li>Repeat each test 2–3 times and average.</li><li>Prefer Ethernet or strong Wi-Fi signal.</li></ul>
   <!-- in-content ad -->
-  <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8054613411767519" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
+  <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8054613417167519" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
   <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
   <p>Ready to test? <a href="/">Run the main speed test</a>.</p>
 </main>

--- a/mobile-speed-test.html
+++ b/mobile-speed-test.html
@@ -10,8 +10,9 @@
 <meta property="og:image" content="https://speedoodle.com/og.png">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <!-- AdSense loader (skip if already in head globally) -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">
@@ -22,7 +23,7 @@
   <h2>Tips for best results</h2>
   <ul><li>Stand near your router (Wi-Fi) or an open area (cellular).</li><li>Close heavy downloads/streams on other devices.</li><li>Repeat the test at different times to see variability.</li></ul>
   <!-- in-content ad -->
-  <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8054613411767519" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
+  <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8054613417167519" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
   <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
   <p>Looking for desktop testing? Try the <a href="/">main speed test</a>.</p>
 </main>

--- a/ping-test.html
+++ b/ping-test.html
@@ -10,7 +10,8 @@
 <meta property="og:image" content="https://speedoodle.com/og.png">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">
@@ -21,7 +22,7 @@
   <h2>Why ping varies</h2>
   <p>Routing, congestion, Wi-Fi interference, and distance to servers can all impact latency.</p>
   <!-- in-content ad -->
-  <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8054613411767519" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
+  <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-8054613417167519" data-ad-slot="1234567890" data-ad-format="auto" data-full-width-responsive="true"></ins>
   <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
   <p>Need a full speed test? Go to the <a href="/">main test</a>.</p>
 </main>

--- a/privacy.html
+++ b/privacy.html
@@ -15,9 +15,9 @@
 <meta name="twitter:description" content="Learn how Speedoodle handles your data and privacy.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
-<meta name="google-adsense-account" content="ca-pub-8054613411767519">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <!-- AdSense verification -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">

--- a/terms.html
+++ b/terms.html
@@ -15,9 +15,9 @@
 <meta name="twitter:description" content="Terms of use for the Speedoodle internet speed test site.">
 <link rel="preconnect" href="https://pagead2.googlesyndication.com">
 <link rel="preconnect" href="https://googleads.g.doubleclick.net">
-<meta name="google-adsense-account" content="ca-pub-8054613411767519">
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <!-- AdSense verification -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613411767519" crossorigin="anonymous"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">


### PR DESCRIPTION
## Summary
- Update AdSense account ID to `ca-pub-8054613417167519` across HTML pages and ads.txt
- Add missing `google-adsense-account` meta tags on ping, ISP comparison, and mobile speed test pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c80ec4c8f0832388368548a9013be9