### PR TITLE
fix: harden run button handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
       </div>
 
       <div id="status" class="subtitle" style="margin-top:10px">Ready</div>
-      <button id="runTest">Start Test</button>
+      <button id="runTest" type="button">Start Test</button>
     </section>
   </main>
   <div class="adbar"><div class="adslot">Ad slot</div></div>
@@ -373,10 +373,35 @@
     }
   }
 
-  btn?.addEventListener('click', startTest);
+  window.startTest = startTest;
   // init
   setGauge(0);
 })();
+  </script>
+  <script>
+  (function(){
+    function ready(fn){
+      document.readyState!=='loading' ? fn() : document.addEventListener('DOMContentLoaded',fn);
+    }
+    ready(function(){
+      const btn = document.getElementById('runTest');
+      if(!btn){ console.warn('runTest button missing'); return; }
+      btn.type = 'button';
+      btn.addEventListener('click', async () => {
+        try {
+          btn.disabled = true;
+          if (typeof window.startTest === 'function') {
+            await window.startTest();
+          } else if (typeof window.runSpeedTest === 'function') {
+            await window.runSpeedTest({});
+          } else {
+            await new Promise(r => setTimeout(r, 800));
+          }
+        } catch(err){ console.error(err); }
+        finally { btn.disabled = false; }
+      });
+    });
+  })();
   </script>
 </body>
 </html>

--- a/site.css
+++ b/site.css
@@ -39,3 +39,5 @@ footer{
 .stat-card .val{font-size:28px;font-weight:800}
 .testing .big-num,.testing .stat-card .val{animation:pulse 1.6s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.9;transform:scale(.992)}}
+.adsbygoogle,#ad-slot-1{position:relative;z-index:1}
+#runTest{position:relative;z-index:2}


### PR DESCRIPTION
## Summary
- ensure the Start Test button uses a single consistent markup and expose `startTest` globally
- add the safe DOM-ready click handler so the button remains functional even if other scripts fail
- raise the button z-index above ad slots to keep it clickable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9098cc1b48323b03c93c4c502d6ac