### PR TITLE
Revamp landing speed test interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
     .tile .unit{display:block;margin-top:4px;font-size:12px;color:var(--muted)}
 
     .go-wrap{display:flex;align-items:center;justify-content:center;gap:16px;margin:10px 0 22px}
-    .go{width:140px;height:140px;border-radius:50%;border:none;cursor:pointer;background:radial-gradient(ellipse at 50% 40%, #23d9cb 0%, #19a396 70%, #0e5f58 100%);color:#00100f;font-weight:800;font-size:32px;letter-spacing:.5px;box-shadow:0 0 0 6px rgba(33,208,195,.15),0 8px 28px rgba(0,0,0,.45)}
-    .go:active{transform:scale(.98)}
+    .go{width:140px;height:140px;border-radius:50%;border:none;cursor:pointer;background:radial-gradient(ellipse at 50% 40%, #23d9cb 0%, #19a396 70%, #0e5f58 100%);color:#00100f;font-weight:800;font-size:32px;letter-spacing:.5px;box-shadow:0 0 0 6px rgba(33,208,195,.15),0 8px 28px rgba(0,0,0,.45);transition:transform .2s ease}
+    .go:active{transform:scale(.95)}
     .busy{display:none;color:var(--muted);font-size:14px;margin-top:10px;text-align:center}
     .busy.show{display:block}
 
@@ -125,53 +125,158 @@
   </div>
 
   <script>
-  (function(){
-    if (window.__speedoodle && window.__speedoodle.initialized) return;
-    window.__speedoodle = { initialized: true };
-    function $(id){ return document.getElementById(id); }
-    function fmt(n,d){ d=(d==null?2:d); return (isFinite(n)?(+n).toFixed(d):'—'); }
-    function clamp(v,a,b){ return Math.min(b,Math.max(a,v)); }
-    function bitsToMbps(bits){ return bits/1e6; }
+'use strict';
+// Self-contained boot; prevents double init
+(function(){
+  if (window.__speedoodle && window.__speedoodle.initialized) return;
+  window.__speedoodle = { initialized: true };
 
-    // ===== Tiny line chart with EMA + bezier smoothing =====
-    function Line(canvas,color){ this.c=canvas; this.ctx=canvas.getContext('2d'); this.color=color; this.data=[]; this._ema=null; this.maxY=10; this.resize(); window.addEventListener('resize', this.resize.bind(this)); }
-    Line.prototype.resize=function(){ var dpr=window.devicePixelRatio||1; this.c.width=this.c.clientWidth*dpr; this.c.height=this.c.clientHeight*dpr; this.ctx.setTransform(1,0,0,1,0,0); this.ctx.scale(dpr,dpr); this.redraw(); };
-    Line.prototype.clear=function(){ this.data=[]; this._ema=null; this.maxY=10; this.redraw(); };
-    Line.prototype.push=function(y){ this._ema=(this._ema==null)?y:this._ema*0.8 + y*0.2; this.data.push(this._ema); this.maxY=Math.max(this.maxY,this._ema*1.1); if(this.data.length>400) this.data.shift(); this.redraw(); };
-    Line.prototype.redraw=function(){ var ctx=this.ctx,W=this.c.clientWidth,H=this.c.clientHeight; ctx.clearRect(0,0,W,H); ctx.strokeStyle='rgba(255,255,255,0.06)'; for(var i=0;i<=4;i++){ var y=H-(H*i/4); ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(W,y); ctx.stroke(); } if(this.data.length<2) return; var step=W/Math.max(this.data.length-1,1); ctx.beginPath(); var x0=0, y0=H-(this.data[0]/this.maxY)*H; ctx.moveTo(x0,y0); for(var j=1;j<this.data.length;j++){ var x=j*step, y=H-(this.data[j]/this.maxY)*H; var mx=(x0+x)/2, my=(y0+y)/2; ctx.quadraticCurveTo(x0,y0,mx,my); x0=x; y0=y; } ctx.quadraticCurveTo(x0,y0,W,H-(this.data[this.data.length-1]/this.maxY)*H); ctx.strokeStyle=this.color; ctx.lineWidth=2; ctx.stroke(); ctx.lineTo(W,H); ctx.lineTo(0,H); ctx.closePath(); ctx.fillStyle='rgba(33,208,195,0.08)'; ctx.fill(); };
+  // ---------- helpers ----------
+  const $ = (id)=>document.getElementById(id);
+  const fmt = (n,d=2)=> (Number.isFinite(+n)?(+n).toFixed(d):'—');
+  const clamp = (v,a,b)=> Math.min(b,Math.max(a,v));
+  const bitsToMbps = (bits)=> bits/1e6;
 
-    // ===== Gauge with spring animation =====
-    var gaugeCanvas=$('scoreCanvas'); var scorePos=0, scoreVel=0, scoreTarget=0, anim=false, last=0;
-    function drawGauge(score){ var g=gaugeCanvas.getContext('2d'); var dpr=window.devicePixelRatio||1; var W=gaugeCanvas.clientWidth,H=gaugeCanvas.clientHeight; gaugeCanvas.width=W*dpr; gaugeCanvas.height=H*dpr; g.setTransform(1,0,0,1,0,0); g.scale(dpr,dpr); var cx=W/2, cy=H*0.95, r=Math.min(cx,cy)-12; g.clearRect(0,0,W,H); g.lineWidth=16; g.lineCap='round'; g.strokeStyle='#243044'; g.beginPath(); g.arc(cx,cy,r,Math.PI,0); g.stroke(); var s=clamp(score,0,100); var grad=g.createLinearGradient(0,0,W,0); grad.addColorStop(0,'#ff5470'); grad.addColorStop(.5,'#f2c94c'); grad.addColorStop(1,'#21d6c7'); g.strokeStyle=grad; g.beginPath(); g.arc(cx,cy,r,Math.PI, Math.PI+Math.PI*(s/100)); g.stroke(); g.save(); g.translate(cx,cy); g.rotate(Math.PI); for(var i2=0;i2<=10;i2++){ var t=i2/10, ang=Math.PI*t, len=(i2%5===0)?12:6; var x1=(r-8)*Math.cos(ang), y1=(r-8)*Math.sin(ang); var x2=(r-8-len)*Math.cos(ang), y2=(r-8-len)*Math.sin(ang); g.strokeStyle='rgba(255,255,255,0.2)'; g.lineWidth=2; g.beginPath(); g.moveTo(x1,y1); g.lineTo(x2,y2); g.stroke(); } g.restore(); var ang=Math.PI+Math.PI*(s/100); var nx=cx+(r-18)*Math.cos(ang), ny=cy+(r-18)*Math.sin(ang); g.strokeStyle='#cde8ff'; g.lineWidth=3; g.beginPath(); g.moveTo(cx,cy); g.lineTo(nx,ny); g.stroke(); }
-    function setScoreTarget(t){ scoreTarget=clamp(+t||0,0,100); if(!anim){ anim=true; last=performance.now(); requestAnimationFrame(loop); } }
-    function loop(now){ var dt=Math.min(0.05,(now-last)/1000); last=now; var k=14, c=8; var a=k*(scoreTarget-scorePos)-c*scoreVel; scoreVel+=a*dt; scorePos+=scoreVel*dt; if(Math.abs(scoreVel)<0.01 && Math.abs(scoreTarget-scorePos)<0.2){ scorePos=scoreTarget; scoreVel=0; anim=false; } $('scoreCenter').textContent=String(Math.round(scorePos)); drawGauge(scorePos); if(anim) requestAnimationFrame(loop); }
+  // Static info
+  if ($('browserVal')) $('browserVal').textContent = navigator.userAgent || '—';
+  if ($('osVal')) $('osVal').textContent = navigator.platform || '—';
 
-    // ===== Scoring =====
-    function scoreConnection(o){ var down=Math.min(o.downMbps/100,1)*35; var up=Math.min(o.upMbps/20,1)*35; var ping=Math.min(15/Math.max(o.pingMs,1),1)*20; var jit=Math.min(5/Math.max(o.jitterMs,1),1)*10; return Math.round(down+up+ping+jit); }
-    function qualityLabel(o){ if(o.downMbps>=3&&o.upMbps>=2.5&&o.pingMs<=60) return 'Excellent for 1080p'; if(o.downMbps>=1.2&&o.upMbps>=1.2&&o.pingMs<=100) return 'Good for 720p'; if(o.downMbps>=0.6&&o.upMbps>=0.6) return 'Okay for basic video'; return 'Poor - audio only'; }
-    function verdictText(o){ var parts=[]; if(o.downMbps<1.2||o.upMbps<1.2) parts.push('Low bandwidth'); if(o.pingMs>80) parts.push('High latency'); if(o.jitterMs>20) parts.push('High jitter'); return parts.length?('• '+parts.join('\n• ')):'Looks great for video calls.'; }
+  // ---------- Live line chart (EMA + Bezier) ----------
+  class Line {
+    constructor(canvas, color){ this.c=canvas; this.ctx=canvas.getContext('2d'); this.color=color; this.data=[]; this._ema=null; this.maxY=10; this._onResize=this.resize.bind(this); this.resize(); window.addEventListener('resize', this._onResize); }
+    resize(){ const dpr=window.devicePixelRatio||1; this.c.width=this.c.clientWidth*dpr; this.c.height=this.c.clientHeight*dpr; this.ctx.setTransform(1,0,0,1,0,0); this.ctx.scale(dpr,dpr); this.redraw(); }
+    clear(){ this.data.length=0; this._ema=null; this.maxY=10; this.redraw(); }
+    push(y){ this._ema = this._ema==null? y : (this._ema*0.8 + y*0.2); this.data.push(this._ema); this.maxY=Math.max(this.maxY,this._ema*1.1); if(this.data.length>400) this.data.shift(); this.redraw(); }
+    redraw(){ const ctx=this.ctx,W=this.c.clientWidth,H=this.c.clientHeight; ctx.clearRect(0,0,W,H);
+      ctx.strokeStyle='rgba(255,255,255,0.06)'; for(let i=0;i<=4;i++){ const y=H-(H*i/4); ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(W,y); ctx.stroke(); }
+      if(this.data.length<2) return; const step=W/Math.max(this.data.length-1,1); ctx.beginPath(); let x0=0,y0=H-(this.data[0]/this.maxY)*H; ctx.moveTo(x0,y0); for(let j=1;j<this.data.length;j++){ const x=j*step, y=H-(this.data[j]/this.maxY)*H; const mx=(x0+x)/2, my=(y0+y)/2; ctx.quadraticCurveTo(x0,y0,mx,my); x0=x; y0=y; } ctx.quadraticCurveTo(x0,y0,W,H-(this.data[this.data.length-1]/this.maxY)*H); ctx.strokeStyle=this.color; ctx.lineWidth=2; ctx.stroke(); ctx.lineTo(W,H); ctx.lineTo(0,H); ctx.closePath(); ctx.fillStyle='rgba(33,208,195,0.08)'; ctx.fill(); }
+  }
+  const line = new Line($('speedCanvas'),'rgba(33,208,195,1)');
 
-    // ===== Endpoints & helpers =====
-    var line=new Line($('speedCanvas'),'rgba(33,208,195,1)');
-    var CF_DOWN='https://speed.cloudflare.com/__down?bytes=';
-    var CF_UP='https://speed.cloudflare.com/__up';
-    function safeFillRandom(u8){ try{ if(!(window.crypto&&window.crypto.getRandomValues)) return; var len=u8.byteLength, step=65536; for(var i=0;i<len;i+=step){ window.crypto.getRandomValues(u8.subarray(i,Math.min(i+step,len))); } }catch(e){} }
+  // ---------- Gauge (spring) ----------
+  const gauge = $('scoreCanvas');
+  let scorePos=0, scoreVel=0, scoreTarget=0, running=false, lastT=0;
+  function drawGauge(score){ const g=gauge.getContext('2d'), dpr=window.devicePixelRatio||1; const W=gauge.clientWidth,H=gauge.clientHeight; gauge.width=W*dpr; gauge.height=H*dpr; g.setTransform(1,0,0,1,0,0); g.scale(dpr,dpr); const cx=W/2, cy=H*0.95, r=Math.min(cx,cy)-12; g.clearRect(0,0,W,H); g.lineWidth=16; g.lineCap='round';
+    g.strokeStyle='#243044'; g.beginPath(); g.arc(cx,cy,r,Math.PI,0); g.stroke();
+    const s=clamp(score,0,100); const grad=g.createLinearGradient(0,0,W,0); grad.addColorStop(0,'#ff5470'); grad.addColorStop(0.5,'#f2c94c'); grad.addColorStop(1,'#21d6c7'); g.strokeStyle=grad; g.beginPath(); g.arc(cx,cy,r,Math.PI, Math.PI+Math.PI*(s/100)); g.stroke();
+    g.save(); g.translate(cx,cy); g.rotate(Math.PI); for(let i=0;i<=10;i++){ const t=i/10, a=Math.PI*t, len=(i%5===0)?12:6; const x1=(r-8)*Math.cos(a), y1=(r-8)*Math.sin(a), x2=(r-8-len)*Math.cos(a), y2=(r-8-len)*Math.sin(a); g.strokeStyle='rgba(255,255,255,0.2)'; g.lineWidth=2; g.beginPath(); g.moveTo(x1,y1); g.lineTo(x2,y2); g.stroke(); } g.restore();
+    const ang=Math.PI+Math.PI*(s/100), nx=cx+(r-18)*Math.cos(ang), ny=cy+(r-18)*Math.sin(ang); g.strokeStyle='#cde8ff'; g.lineWidth=3; g.beginPath(); g.moveTo(cx,cy); g.lineTo(nx,ny); g.stroke(); }
+  function setScoreTarget(t){ scoreTarget=clamp(+t||0,0,100); if(!running){ running=true; lastT=performance.now(); requestAnimationFrame(step); } }
+  function step(now){ const dt=Math.min(0.05,(now-lastT)/1000); lastT=now; const k=14, c=8; const a=k*(scoreTarget-scorePos)-c*scoreVel; scoreVel+=a*dt; scorePos+=scoreVel*dt; if(Math.abs(scoreVel)<0.01 && Math.abs(scoreTarget-scorePos)<0.2){ scorePos=scoreTarget; scoreVel=0; running=false; } $('scoreCenter').textContent=String(Math.round(scorePos)); drawGauge(scorePos); if(running) requestAnimationFrame(step); }
 
-    // ===== Tests =====
-    function fetchWithTimeout(url, opts, timeoutMs){ opts=opts||{}; var c=('AbortController' in window)?new AbortController():null; if(c) opts.signal=c.signal; var t=setTimeout(function(){ if(c) c.abort(); }, timeoutMs||2000); return fetch(url,opts).finally(function(){ clearTimeout(t); }); }
-    function testPing(samples){ samples=samples||4; var t=[],i=0; function one(){ var t0=performance.now(); return fetchWithTimeout(CF_DOWN+'1',{cache:'no-store',mode:'cors'},1200).then(function(){ t.push(performance.now()-t0); }).catch(function(){ t.push(1200); }); } var seq=Promise.resolve(); for(i=0;i<samples;i++){ seq=seq.then(one);} return seq.then(function(){ var mean=t.length?t.reduce(function(a,b){return a+b;},0)/t.length:Infinity; var jit=t.length?Math.sqrt(t.map(function(x){return Math.pow(x-mean,2);}).reduce(function(a,b){return a+b;},0)/t.length):Infinity; return {pingMs:mean,jitterMs:jit}; }); }
-    function testDownload(ms,parallel){ ms=ms||3500; parallel=parallel||3; var loaded=0; var start=performance.now(), end=start+ms; var dlEMA=null; function run(){ return new Promise(function(resolve){ (function loop(){ if(performance.now()>=end){ resolve(); return;} var size=4*1024*1024; fetchWithTimeout(CF_DOWN+size,{cache:'no-store',mode:'cors'},2000).then(function(r){return r.arrayBuffer();}).then(function(b){ loaded+=(b&&b.byteLength?b.byteLength:0)*8; }).catch(function(){}).finally(function(){ var elapsed=(performance.now()-start)/1000; var mbps=bitsToMbps(loaded/Math.max(elapsed,0.001)); dlEMA = (dlEMA==null)?mbps:(dlEMA*0.8+mbps*0.2); line.push(dlEMA); loop(); }); })(); }); } var ps=[]; for(var k=0;k<parallel;k++){ ps.push(run()); } return Promise.all(ps).then(function(){ return {downMbps: bitsToMbps(loaded/(ms/1000))}; }); }
-    function testUpload(ms,parallel){ ms=ms||2500; parallel=parallel||2; var payload=new Uint8Array(64*1024); safeFillRandom(payload); var sent=0; var start=performance.now(), end=start+ms; var usingBeacon=false; setTimeout(function(){ if(sent===0 && 'sendBeacon' in navigator){ usingBeacon=true; var n=$('uplNote'); if(n) n.textContent='using beacon fallback'; } },1000); function run(){ return new Promise(function(resolve){ (function loop(){ if(performance.now()>=end){ resolve(); return;} if(usingBeacon && navigator.sendBeacon){ try{ if(navigator.sendBeacon(CF_UP,payload)) sent+=payload.byteLength*8; }catch(e){} setTimeout(loop,0); return; } fetchWithTimeout(CF_UP,{method:'POST',mode:'cors',cache:'no-store',headers:{'Content-Type':'application/octet-stream'},body:payload},1500).then(function(){ sent+=payload.byteLength*8; }).catch(function(){ }).finally(function(){ loop(); }); })(); }); } var ps=[]; for(var k=0;k<parallel;k++){ ps.push(run()); } return Promise.all(ps).then(function(){ return {upMbps: bitsToMbps(sent/(ms/1000))}; }); }
+  // ---------- score ----------
+  function scoreConnection(o){ const down=Math.min(o.downMbps/100,1)*35; const up=Math.min(o.upMbps/20,1)*35; const ping=Math.min(15/Math.max(o.pingMs,1),1)*20; const jit=Math.min(5/Math.max(o.jitterMs,1),1)*10; return Math.round(down+up+ping+jit); }
+  function qualityLabel(o){ if(o.downMbps>=3&&o.upMbps>=2.5&&o.pingMs<=60) return 'Excellent for 1080p'; if(o.downMbps>=1.2&&o.upMbps>=1.2&&o.pingMs<=100) return 'Good for 720p'; if(o.downMbps>=0.6&&o.upMbps>=0.6) return 'Okay for basic video'; return 'Poor - audio only'; }
+  function verdictText(o){ const parts=[]; if(o.downMbps<1.2||o.upMbps<1.2) parts.push('Low bandwidth'); if(o.pingMs>80) parts.push('High latency'); if(o.jitterMs>20) parts.push('High jitter'); return parts.length?('• '+parts.join('\n• ')):'Looks great for video calls.'; }
 
-    // ===== Demo fallback =====
-    function runDemo(){ var ping=parseFloat(($('pingVal')||{}).textContent)||140; var jitter=parseFloat(($('jitterVal')||{}).textContent)||40; line.clear(); var cur=5, steps=140, i=0; function tick(){ var target=i<90?Math.min(180,cur+Math.random()*6):Math.max(40,cur-Math.random()*3); cur=Math.max(5,Math.min(200,target)); line.push(cur); setScoreTarget(scoreConnection({downMbps:cur,upMbps:0.8,pingMs:ping,jitterMs:jitter})); i++; if(i<steps) return setTimeout(tick,35); var dl=Math.max(30,Math.min(200,cur+(Math.random()*10-5))); var ul=0.8+Math.random()*1.2; $('dlVal').textContent=fmt(dl,2); $('ulVal').textContent=fmt(ul,2); var all={downMbps:dl,upMbps:ul,pingMs:ping,jitterMs:jitter}; setScoreTarget(scoreConnection(all)); $('scoreBadge').textContent=qualityLabel(all); $('verdict').textContent=verdictText(all)+' (demo)'; } tick(); }
+  // ---------- endpoints ----------
+  const CF_DOWN='https://speed.cloudflare.com/__down?bytes=';
+  const CF_UP  ='https://speed.cloudflare.com/__up';
+  function fetchWithTimeout(url,opts={},timeoutMs=2000){ const c=('AbortController' in window)?new AbortController():null; if(c) opts.signal=c.signal; const t=setTimeout(()=>{ if(c) c.abort(); }, timeoutMs); return fetch(url,opts).finally(()=>clearTimeout(t)); }
+  function safeFillRandom(u8){ try{ if(!(crypto&&crypto.getRandomValues)) return; for(let i=0;i<u8.byteLength;i+=65536){ crypto.getRandomValues(u8.subarray(i,Math.min(i+65536,u8.byteLength))); } }catch(_){} }
 
-    // ===== Button wiring =====
-    $('startBtn').onclick=function(){ $('busy').classList.add('show'); scorePos=0; $('scoreCenter').textContent='0'; drawGauge(0); $('dlVal').textContent='—'; $('ulVal').textContent='—'; $('verdict').textContent='Testing...'; var n=$('uplNote'); if(n) n.textContent=''; $('scoreBadge').textContent='—'; line.clear(); var wd=setTimeout(function(){ if($('busy').classList.contains('show')){ runDemo(); $('busy').classList.remove('show'); } },15000); testPing().then(function(p){ $('pingVal').textContent=fmt(p.pingMs,0); $('jitterVal').textContent=fmt(p.jitterMs,0); return testDownload(); }).then(function(dl){ $('dlVal').textContent=fmt(dl.downMbps,2); setScoreTarget(scoreConnection({downMbps:dl.downMbps,upMbps:0,pingMs:parseFloat($('pingVal').textContent)||Infinity,jitterMs:parseFloat($('jitterVal').textContent)||Infinity})); return testUpload(); }).then(function(ul){ $('ulVal').textContent=fmt(ul.upMbps,2); var all={downMbps:parseFloat($('dlVal').textContent)||0, upMbps:ul.upMbps||0, pingMs:parseFloat($('pingVal').textContent)||Infinity, jitterMs:parseFloat($('jitterVal').textContent)||Infinity}; setScoreTarget(scoreConnection(all)); $('scoreBadge').textContent=qualityLabel(all); $('verdict').textContent=verdictText(all); }).catch(function(){ runDemo(); }).finally(function(){ clearTimeout(wd); $('busy').classList.remove('show'); }); };
+  // ---------- tests ----------
+  function testPing(samples=4){ const arr=[]; const one=()=>{ const t0=performance.now(); return fetchWithTimeout(CF_DOWN+'1',{cache:'no-store',mode:'cors'},1200).then(()=>arr.push(performance.now()-t0)).catch(()=>arr.push(1200)); }; let p=Promise.resolve(); for(let i=0;i<samples;i++) p=p.then(one); return p.then(()=>{ const mean=arr.length?arr.reduce((a,b)=>a+b,0)/arr.length:Infinity; const jit=arr.length?Math.sqrt(arr.map(x=>(x-mean)**2).reduce((a,b)=>a+b,0)/arr.length):Infinity; return {pingMs:mean,jitterMs:jit}; }); }
+  function testDownload(ms=3500, parallel=3){ let loaded=0; const start=performance.now(), end=start+ms; let dlEMA=null; function run(){ return new Promise((resolve)=>{ (function loop(){ if(performance.now()>=end){ resolve(); return; } const size=4*1024*1024; fetchWithTimeout(CF_DOWN+size,{cache:'no-store',mode:'cors'},2000).then(r=>r.arrayBuffer()).then(b=>{ loaded+=(b&&b.byteLength?b.byteLength:0)*8; }).catch(()=>{}).finally(()=>{ const elapsed=(performance.now()-start)/1000; const mbps=bitsToMbps(loaded/Math.max(elapsed,0.001)); dlEMA = dlEMA==null? mbps : (dlEMA*0.8 + mbps*0.2); line.push(dlEMA); loop(); }); })(); }); } const ps=[]; for(let k=0;k<parallel;k++) ps.push(run()); return Promise.all(ps).then(()=>({downMbps: bitsToMbps(loaded/(ms/1000))})); }
+  function testUpload(ms=2500, parallel=2){ const payload=new Uint8Array(64*1024); safeFillRandom(payload); let sent=0; const start=performance.now(), end=start+ms; let usingBeacon=false; setTimeout(()=>{ if(sent===0 && 'sendBeacon' in navigator){ usingBeacon=true; const n=$('uplNote'); if(n) n.textContent='using beacon fallback'; } },1000); function run(){ return new Promise((resolve)=>{ (function loop(){ if(performance.now()>=end){ resolve(); return; } if(usingBeacon && navigator.sendBeacon){ try{ if(navigator.sendBeacon(CF_UP,payload)) sent+=payload.byteLength*8; }catch(_){} setTimeout(loop,0); return; } fetchWithTimeout(CF_UP,{method:'POST',mode:'cors',cache:'no-store',headers:{'Content-Type':'application/octet-stream'},body:payload},1500).then(()=>{ sent+=payload.byteLength*8; }).catch(()=>{}).finally(()=>loop()); })(); }); } const ps=[]; for(let k=0;k<parallel;k++) ps.push(run()); return Promise.all(ps).then(()=>({upMbps: bitsToMbps(sent/(ms/1000))})); }
 
-    // ===== System info (unchanged) =====
-    (function(){ if($('browserVal')) $('browserVal').textContent=navigator.userAgent||'—'; if($('osVal')) $('osVal').textContent=navigator.platform||'—'; try{ fetch('https://api.ipify.org?format=json').then(function(r){return r.json();}).then(function(j){ if($('ipVal')) $('ipVal').textContent=(j&&j.ip)?j.ip:'—'; }).catch(function(){}); }catch(e){} try{ fetch('https://ipapi.co/json/').then(function(r){return r.json();}).then(function(d){ var txt=(d&&d.org)? d.org + (d&&d.country_name? ' - ' + d.country_name : '') : '—'; if($('ispVal')) $('ispVal').textContent=txt; }).catch(function(){}); }catch(e){} })();
-  })();
+  // ---------- demo ----------
+  function runDemo(){ const ping=parseFloat(($('pingVal')||{}).textContent)||140; const jitter=parseFloat(($('jitterVal')||{}).textContent)||40; line.clear(); let cur=5, steps=140, i=0; (function tick(){ const target=i<90?Math.min(180,cur+Math.random()*6):Math.max(40,cur-Math.random()*3); cur=Math.max(5,Math.min(200,target)); line.push(cur); setScoreTarget(scoreConnection({downMbps:cur,upMbps:0.8,pingMs:ping,jitterMs:jitter})); i++; if(i<steps){ setTimeout(tick,35); return; } const dl=Math.max(30,Math.min(200,cur+(Math.random()*10-5))); const ul=0.8+Math.random()*1.2; $('dlVal').textContent=fmt(dl,2); $('ulVal').textContent=fmt(ul,2); const all={downMbps:dl,upMbps:ul,pingMs:ping,jitterMs:jitter}; setScoreTarget(scoreConnection(all)); $('scoreBadge').textContent=qualityLabel(all); $('verdict').textContent=verdictText(all)+' (demo)'; })(); }
+
+  // ---------- CPU & memory ----------
+  function setBadge(id,pct){ const el=$(id); if(!el) return; el.classList.remove('status-ok','status-warn','status-bad'); if(pct<60){ el.textContent='OK'; el.classList.add('status-ok'); } else if(pct<85){ el.textContent='High'; el.classList.add('status-warn'); } else { el.textContent='Very High'; el.classList.add('status-bad'); } }
+  let longTaskMs=0, lastTick=performance.now();
+  try{ if('PerformanceObserver' in window){ const po=new PerformanceObserver((list)=>{ const es=list.getEntries(); for(let i=0;i<es.length;i++) longTaskMs += es[i].duration||0; }); po.observe({type:'longtask', buffered:true}); } }catch(_){ }
+  const frameDur=[]; (function rafSampler(){ let prev=performance.now(); function s(t){ frameDur.push(t-prev); if(frameDur.length>60) frameDur.shift(); prev=t; requestAnimationFrame(s);} requestAnimationFrame(s);} )();
+  function updateCPU(){ const now=performance.now(), windowMs=now-lastTick; const lagMs=Math.max(0,windowMs-1000); let busyMs=Math.min(windowMs,longTaskMs+lagMs); if(frameDur.length){ const avg=frameDur.reduce((a,b)=>a+b,0)/frameDur.length; const slow=Math.max(0,avg-16.7); busyMs += Math.min(windowMs, slow*60); } const busyPct=clamp(Math.round((busyMs/windowMs)*100),0,100); try{ $('cpuVal').textContent=busyPct+'%'; $('cpuBar').style.width=busyPct+'%'; setBadge('cpuBadge',busyPct);}catch(_){} longTaskMs=0; lastTick=now; }
+  function updateMemory(){ try{ if(performance && performance.memory && performance.memory.usedJSHeapSize){ const used=performance.memory.usedJSHeapSize; const total=performance.memory.totalJSHeapSize||performance.memory.jsHeapSizeLimit||0; const usedMB=Math.round(used/1048576); const totalMB= total? Math.round(total/1048576):null; const pct= total? Math.min(100, Math.round((used/total)*100)) : null; $('memVal').textContent= totalMB? (usedMB+' / '+totalMB+' MB ('+pct+'%)') : (usedMB+' MB'); if(pct!=null){ $('memBar').style.width=pct+'%'; setBadge('memBadge',pct);} else { $('memBadge').textContent='Est.'; $('memBar').style.width='30%'; } } else if (navigator.deviceMemory){ const gb=navigator.deviceMemory; $('memVal').textContent = gb + ' GB (device)'; $('memBadge').textContent='Est.'; $('memBar').style.width='30%'; } else { $('memVal').textContent='Unavailable on iOS Safari'; $('memBadge').textContent='N/A'; $('memBar').style.width='0%'; } }catch(_){ try{$('memVal').textContent='Unavailable'; $('memBadge').textContent='N/A'; $('memBar').style.width='0%';}catch(e){} }
+  }
+  updateMemory(); updateCPU(); setInterval(updateMemory,1500); setInterval(updateCPU,1000);
+
+  // ---------- CSV ----------
+  if($('metricsCsv')) $('metricsCsv').onclick=function(){ const header='timestamp,cpu_percent,mem\n'; const rows=[]; let i=0; (function grab(){ const cpu=($('cpuVal')||{}).textContent||''; const mem=($('memVal')||{}).textContent||''; rows.push(new Date().toISOString()+','+cpu+','+mem); if(++i<10) return setTimeout(grab,1000); const csv=header+rows.join('\n'); try{ const blob=new Blob([csv],{type:'text/csv'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='speedoodle_metrics.csv'; a.rel='noopener'; a.target=(/iPhone|iPad|iPod/i.test(navigator.userAgent)?'_blank':''); document.body.appendChild(a); a.click(); setTimeout(()=>{ URL.revokeObjectURL(url); a.remove(); },1500);}catch(_){ const data='data:text/plain;charset=utf-8,'+encodeURIComponent(csv); window.open(data,'_blank'); } })(); };
+
+  // ---------- Button wiring (with explicit reasons) ----------
+  $('startBtn').onclick=function(){
+    $('busy').classList.add('show');
+    scorePos=0; $('scoreCenter').textContent='0'; drawGauge(0);
+    $('dlVal').textContent='—'; $('ulVal').textContent='—'; $('verdict').textContent='Testing...';
+    const note=$('uplNote'); if(note) note.textContent='';
+    $('scoreBadge').textContent='—'; line.clear();
+
+    const reasons=[]; const add=(r)=>{ if(reasons.indexOf(r)===-1) reasons.push(r); };
+    const setVerdict=()=>{ $('verdict').textContent = reasons.length? ('Issues detected:\n• '+reasons.join('\n• ')) : 'Looks great for video calls.'; };
+
+    const watchdog=setTimeout(function(){ if($('busy').classList.contains('show')){ add('Network blocked or timed out'); setVerdict(); runDemo(); $('busy').classList.remove('show'); } },15000);
+
+    testPing().then(function(p){
+      if(!isFinite(p.pingMs)) add('Ping failed');
+      $('pingVal').textContent=fmt(p.pingMs,0);
+      $('jitterVal').textContent=fmt(p.jitterMs,0);
+      return testDownload();
+    }).then(function(dl){
+      if(!dl || !isFinite(dl.downMbps) || dl.downMbps<=0) add('Download blocked/timeout');
+      $('dlVal').textContent=fmt((dl&&dl.downMbps)||0,2);
+      const tmp={downMbps:(dl&&dl.downMbps)||0,upMbps:0,pingMs:parseFloat($('pingVal').textContent)||Infinity,jitterMs:parseFloat($('jitterVal').textContent)||Infinity};
+      setScoreTarget(scoreConnection(tmp));
+      return testUpload();
+    }).then(function(ul){
+      const up=(ul&&ul.upMbps)||0;
+      $('ulVal').textContent=fmt(up,2);
+      if(up<=0.01) add('Upload blocked/timeout');
+      const all={downMbps:parseFloat($('dlVal').textContent)||0, upMbps:up, pingMs:parseFloat($('pingVal').textContent)||Infinity, jitterMs:parseFloat($('jitterVal').textContent)||Infinity};
+      setScoreTarget(scoreConnection(all));
+      $('scoreBadge').textContent=qualityLabel(all);
+      setVerdict();
+    }).catch(function(){
+      add('Network blocked or timed out');
+      setVerdict();
+      runDemo();
+    }).finally(function(){ clearTimeout(watchdog); $('busy').classList.remove('show'); });
+  };
+
+  // ---------- smoke tests (console only, never throw) ----------
+  try{
+    console.assert(scoreConnection({downMbps:0,upMbps:0,pingMs:999,jitterMs:999})===0,'score low bound');
+    console.assert(scoreConnection({downMbps:200,upMbps:100,pingMs:1,jitterMs:1})<=100,'score hi bound');
+    console.assert(typeof Line === 'function' && line instanceof Line, 'Line class ready');
+  }catch(_){/* ignore */}
+})();
+  </script>
+
+  <script>
+// Mobile-friendly IP/ISP fallback + iOS memory label
+(function(){
+  const $=id=>document.getElementById(id);
+  function withTimeout(p,ms){return new Promise(function(res,rej){const t=setTimeout(()=>rej(new Error('timeout')),ms);p.then(v=>{clearTimeout(t);res(v);},e=>{clearTimeout(t);rej(e);});});}
+  function tryJson(url){return withTimeout(fetch(url,{cache:'no-store',mode:'cors'}),2500).then(r=>r.json());}
+  // Memory label for Safari/iOS
+  try{
+    if(!(performance&&performance.memory) && !('deviceMemory' in navigator)){
+      if($('memVal')) $('memVal').textContent='Unavailable on iOS Safari';
+      if($('memBadge')) $('memBadge').textContent='N/A';
+    }
+  }catch(_){ }
+  // IP/ISP only if empty
+  const needIp = $('ipVal') && (!$('ipVal').textContent || $('ipVal').textContent==='—');
+  const needIsp = $('ispVal') && (!$('ispVal').textContent || $('ispVal').textContent==='—');
+  if(needIp || needIsp){
+    (async function(){
+      let ip='—', isp='—';
+      const ipSources=[
+        ()=>tryJson('https://api64.ipify.org?format=json').then(j=>j.ip),
+        ()=>tryJson('https://api.ipify.org?format=json').then(j=>j.ip),
+        ()=>tryJson('https://ipwho.is/').then(j=>j.ip),
+        ()=>tryJson('https://ipapi.co/json/').then(j=>j.ip)
+      ];
+      for (let f of ipSources){ try{ ip=await f(); if(ip) break; }catch(e){} }
+      try{ let d=await tryJson('https://ipapi.co/json/'); isp=(d.org||d.org_name||'')+(d.country_name? ' - '+d.country_name:''); }
+      catch(_){ try{ let d=await tryJson('https://ipwho.is/'); isp=((d.connection&&d.connection.isp)?d.connection.isp:(d.org||''))+(d.country? ' - '+d.country:''); }catch(__){} }
+      if($('ipVal')) $('ipVal').textContent=ip||'—';
+      if($('ispVal')) $('ispVal').textContent=isp||'—';
+    })();
+  }
+})();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the landing page layout and visuals for the speed test dashboard
- enhance the JavaScript logic with richer metrics, status messaging, and demo fallbacks
- add CPU/memory monitoring, CSV export, and resilient IP lookup helpers

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68cb55c9f6508323a744c3928c853888