### PR TITLE
Add Vercel Analytics script to static pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,4 +16,6 @@
 <p>Suggestions? <a href="mailto:hello@speedoodle.com">hello@speedoodle.com</a></p>
 </main>
 <footer><a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a> · <a href="about.html">About</a> · <a href="contact.html">Contact</a></footer>
+<script defer src="https://vercel.com/analytics/script.js"></script>
+<script>window.va=window.va||function(){(window.vaq=window.vaq||[]).push(arguments)};</script>
 </body></html>

--- a/contact.html
+++ b/contact.html
@@ -17,4 +17,6 @@
 <p>You can switch to a form service later (e.g., Formspree).</p>
 </main>
 <footer><a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a> · <a href="about.html">About</a> · <a href="contact.html">Contact</a></footer>
+<script defer src="https://vercel.com/analytics/script.js"></script>
+<script>window.va=window.va||function(){(window.vaq=window.vaq||[]).push(arguments)};</script>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -278,5 +278,12 @@
   }
 })();
   </script>
+
+  <script defer src="https://vercel.com/analytics/script.js"></script>
+  <script>
+    window.va = window.va || function () {
+      (window.vaq = window.vaq || []).push(arguments);
+    };
+  </script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -12,6 +12,7 @@
 <h2>What we collect</h2>
 <ul>
   <li><strong>Technical data</strong>: truncated/anonymous IP, browser type, language, referrers, basic usage stats.</li>
+  <li><strong>Page views</strong>: aggregated visits/pages from Vercel Analytics (no personally identifying data).</li>
   <li><strong>Cookies</strong>: for basic customization and measurement. You can block cookies in your browser.</li>
   <li><strong>Contact forms</strong>: name, email, and message—only if you submit the <a href="contact.html">contact form</a>.</li>
 </ul>
@@ -33,4 +34,6 @@
 <p>We may update this policy. Continued use constitutes acceptance of the updated policy.</p>
 </main>
 <footer><a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a> · <a href="about.html">About</a> · <a href="contact.html">Contact</a></footer>
+<script defer src="https://vercel.com/analytics/script.js"></script>
+<script>window.va=window.va||function(){(window.vaq=window.vaq||[]).push(arguments)};</script>
 </body></html>

--- a/terms.html
+++ b/terms.html
@@ -27,4 +27,6 @@
 <p><a href="mailto:hello@speedoodle.com">hello@speedoodle.com</a></p>
 </main>
 <footer><a href="privacy.html">Privacy</a> · <a href="terms.html">Terms</a> · <a href="about.html">About</a> · <a href="contact.html">Contact</a></footer>
+<script defer src="https://vercel.com/analytics/script.js"></script>
+<script>window.va=window.va||function(){(window.vaq=window.vaq||[]).push(arguments)};</script>
 </body></html>


### PR DESCRIPTION
## Summary
- embed the Vercel Analytics script across the static pages so visits are tracked after deployment
- document the new page view analytics collection in the privacy policy

## Testing
- not run (static HTML change)

------
https://chatgpt.com/codex/tasks/task_e_68cbaabe6db883239f1feb216e8ab342