### PR TITLE
Implement SEO foundations for Speedoodle

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Speedoodle Blog | Video Call Speed Insights</title>
+  <meta name="description" content="Read Speedoodle's latest tips on internet performance for Zoom, Google Meet, and Teams video calls." />
+  <link rel="canonical" href="https://www.speedoodle.com/blog/" />
+  <meta property="og:title" content="Speedoodle Blog | Video Call Speed Insights" />
+  <meta property="og:description" content="Guides on latency, jitter, and bandwidth for crystal-clear video meetings." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.speedoodle.com/blog/" />
+  <meta property="og:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Speedoodle Blog | Video Call Speed Insights" />
+  <meta name="twitter:description" content="Guides on latency, jitter, and bandwidth for crystal-clear video meetings." />
+  <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <link rel="stylesheet" href="/site.css" />
+</head>
+<body>
+  <header>
+    <a href="/">Speedoodle 🚀</a>
+  </header>
+  <main class="container">
+    <h1>Video Call Speed Test Blog</h1>
+    <p>Browse practical tutorials and research-backed advice to keep your video conferences sharp and reliable.</p>
+    <article class="stat-card">
+      <h2>How Much Bandwidth Do I Need for Zoom?</h2>
+      <p class="label">Updated Guides</p>
+      <p class="val">Explore upstream, downstream, and jitter targets for HD calls plus tips for sharing Wi-Fi with your household.</p>
+    </article>
+    <article class="stat-card">
+      <h2>Lowering Latency for Hybrid Teams</h2>
+      <p class="label">Network Optimization</p>
+      <p class="val">Learn about QoS rules, wired vs. wireless tradeoffs, and how to keep Teams and Meet responsive during peak hours.</p>
+    </article>
+    <article class="stat-card">
+      <h2>Understanding Packet Loss in Video Meetings</h2>
+      <p class="label">Troubleshooting</p>
+      <p class="val">Decode how packet loss distorts audio, how to interpret Speedoodle results, and when to call your ISP.</p>
+    </article>
+  </main>
+  <footer>
+    <p>© 2025 Speedoodle. <a href="/contact.html">Contact us</a> for partnership inquiries.</p>
+  </footer>
+</body>
+</html>

--- a/faq/index.html
+++ b/faq/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Speedoodle FAQ | Video Call Speed Questions Answered</title>
+  <meta name="description" content="Get answers about latency, jitter, packet loss, and upload speeds for smooth video calls with Speedoodle." />
+  <link rel="canonical" href="https://www.speedoodle.com/faq/" />
+  <meta property="og:title" content="Speedoodle FAQ | Video Call Speed Questions Answered" />
+  <meta property="og:description" content="Understand the internet speed metrics that keep your video calls stable." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.speedoodle.com/faq/" />
+  <meta property="og:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Speedoodle FAQ | Video Call Speed Questions Answered" />
+  <meta name="twitter:description" content="Understand the internet speed metrics that keep your video calls stable." />
+  <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <link rel="stylesheet" href="/site.css" />
+</head>
+<body>
+  <header>
+    <a href="/">Speedoodle 🚀</a>
+  </header>
+  <main class="container">
+    <h1>Video Call Speed Test FAQ</h1>
+    <section class="stat-card">
+      <h2>Why do latency and ping matter for video calls?</h2>
+      <p class="val">Latency represents the time it takes data to travel to a meeting server and back. Lower ping keeps conversations snappy and prevents participants from talking over one another.</p>
+    </section>
+    <section class="stat-card">
+      <h2>What is jitter and how can I reduce it?</h2>
+      <p class="val">Jitter is the variation in packet delivery times. Use wired connections, prioritize real-time traffic on your router, and avoid congested Wi-Fi channels to keep jitter low.</p>
+    </section>
+    <section class="stat-card">
+      <h2>Do upload speeds matter as much as download?</h2>
+      <p class="val">Yes. Upload throughput carries your audio and video stream to everyone else. For HD calls we recommend at least 3 Mbps upload and a little headroom for screen sharing.</p>
+    </section>
+    <section class="stat-card">
+      <h2>How does packet loss impact Zoom or Teams?</h2>
+      <p class="val">Packet loss causes frozen faces and garbled audio. If Speedoodle reports persistent loss above 1%, restart your modem, reduce background traffic, or contact your ISP.</p>
+    </section>
+  </main>
+  <footer>
+    <p>Need more help? <a href="/contact.html">Message the Speedoodle team</a>.</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,20 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Speedoodle — Internet Speed Test + Call Quality Score</title>
-  <meta name="description" content="Download/Upload/Ping/Jitter + live graph + 0–100 call quality score." />
+  <title>Video Call Speed Test 🚀 | Speedoodle</title>
+  <meta name="description" content="Check if your internet is ready for Zoom, Google Meet, or Teams calls. Speedoodle 🚀 runs a quick speed test tailored for video conferencing stability." />
+  <meta name="keywords" content="video call speed test, zoom speed test, google meet speed test, microsoft teams internet test, voip speed test, internet speed for video conferencing, online video call quality test" />
+  <link rel="canonical" href="https://www.speedoodle.com/" />
+  <meta property="og:title" content="Video Call Speed Test 🚀 | Speedoodle" />
+  <meta property="og:description" content="Is your connection ready for video calls? Test your internet for Zoom, Google Meet, and Teams with Speedoodle." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.speedoodle.com/" />
+  <meta property="og:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Video Call Speed Test 🚀 | Speedoodle" />
+  <meta name="twitter:description" content="Is your connection ready for video calls? Test your internet for Zoom, Google Meet, and Teams with Speedoodle." />
+  <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <link rel="preload" as="image" href="https://www.speedoodle.com/thumbnail.png" />
   <style>
     :root{ --bg:#0b1020; --panel:#171e2b; --border:#2b3546; --muted:#9aa6bd; --text:#e6edf6; --teal:#21d0c3; --good:#21d6c7; --warn:#f2c94c; --bad:#ff5470; }
     *{box-sizing:border-box}
@@ -13,7 +25,8 @@
     .container{max-width:1100px;margin:0 auto;padding:24px}
     header{text-align:center;margin-top:8px}
     header h1{font-weight:800;letter-spacing:.2px;margin:0;font-size:28px}
-    header p{margin:.5rem 0 0;color:var(--muted)}
+    header .brand{margin:0;font-weight:700;font-size:16px;text-transform:uppercase;letter-spacing:1.5px;color:var(--muted)}
+    header .tagline{margin:.5rem 0 0;color:var(--muted)}
 
     .tiles{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:18px;margin:28px 0}
     .tile{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:18px;text-align:center}
@@ -48,12 +61,36 @@
     .status-ok{color:#b8f3ea}.status-warn{color:#f2c94c}.status-bad{color:#ff7b91}
     @media(max-width:860px){ .tiles{grid-template-columns:repeat(2,1fr)} .grid-4{grid-template-columns:1fr} }
   </style>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Speedoodle",
+    "url": "https://www.speedoodle.com",
+    "description": "Video call speed test tailored for Zoom, Google Meet, and Teams.",
+    "potentialAction": {
+      "@type": "Action",
+      "name": "Run Video Call Speed Test"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Speedoodle",
+    "applicationCategory": "WebApplication",
+    "operatingSystem": "Any",
+    "offers": { "@type": "Offer", "price": "0" }
+  }
+  </script>
 </head>
 <body>
   <div class="container">
     <header>
-      <h1>Speedoodle <span style="color:var(--teal)">🚀</span></h1>
-      <p>Internet Speed Test + Call Quality Score</p>
+      <p class="brand">Speedoodle <span style="color:var(--teal)">🚀</span></p>
+      <h1>Video Call Speed Test</h1>
+      <p class="tagline">Check if your internet is ready for Zoom, Google Meet, or Teams calls.</p>
     </header>
 
     <section class="tiles">

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
-Sitemap: https://speedoodle.vercel.app/sitemap.xml
+Sitemap: https://www.speedoodle.com/sitemap.xml
+Host: https://www.speedoodle.com

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://speedoodle.vercel.app/</loc></url>
-  <url><loc>https://speedoodle.vercel.app/privacy.html</loc></url>
-  <url><loc>https://speedoodle.vercel.app/terms.html</loc></url>
-  <url><loc>https://speedoodle.vercel.app/about.html</loc></url>
-  <url><loc>https://speedoodle.vercel.app/contact.html</loc></url>
+  <url><loc>https://www.speedoodle.com/</loc></url>
+  <url><loc>https://www.speedoodle.com/blog/</loc></url>
+  <url><loc>https://www.speedoodle.com/faq/</loc></url>
+  <url><loc>https://www.speedoodle.com/privacy.html</loc></url>
+  <url><loc>https://www.speedoodle.com/terms.html</loc></url>
+  <url><loc>https://www.speedoodle.com/about.html</loc></url>
+  <url><loc>https://www.speedoodle.com/contact.html</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- refresh the homepage head with canonical SEO metadata, Open Graph/Twitter cards, and structured data for Speedoodle
- ensure the homepage hero copies align with the video call speed test niche and preload the share image
- add dedicated blog and FAQ pages plus updated robots.txt and sitemap.xml entries for key routes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc0bd5480c8323b721c2e883164443