### PR TITLE
Add Vercel Analytics integration

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,1 @@
+/* Global styles for Speedoodle Next.js app */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,21 @@
+import "./globals.css";
+import { Inter } from "next/font/google";
+import { Analytics } from "@vercel/analytics/react";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata = {
+  title: "Speedoodle 🚀 — Internet Speed Test",
+  description: "Check your internet speed instantly with Speedoodle 🚀",
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        {children}
+        <Analytics />
+      </body>
+    </html>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "speedoodle",
+  "version": "1.0.0",
+  "description": "אתר קטן בסגנון Fast.com לבדיקת מהירות (הורדה, העלאה ופינג) מול Cloudflare.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@vercel/analytics": "latest"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Next.js root layout that wires up the Inter font, default metadata, and Vercel Analytics
- add a placeholder global stylesheet referenced by the layout
- record the @vercel/analytics dependency in package.json

## Testing
- npm install @vercel/analytics *(fails with 403 Forbidden from registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d00fcdf1748323a6d22f0a39471cbd