### PR TITLE
Add Google Analytics to Next.js layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import Script from "next/script";
 import { Inter } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 
@@ -12,6 +13,20 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
+      <head>
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-LD6QWT7SJ0');
+    `}
+        </Script>
+      </head>
       <body className={inter.className}>
         {children}
         <Analytics />


### PR DESCRIPTION
## Summary
- import the Next.js Script component in the root layout
- inject Google Analytics tag manager scripts into the HTML head

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d45cb2193c8323ab166f3239ee5aab