### PR TITLE
Add Google Analytics tag to static pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,6 +2,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>About | Speedoodle 🚀</title>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+<script>
+window.dataLayer=window.dataLayer||[];
+function gtag(){dataLayer.push(arguments);}
+gtag('js',new Date());
+gtag('config','G-LD6QWT7SJ0');
+</script>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>

--- a/blog/index.html
+++ b/blog/index.html
@@ -15,6 +15,13 @@
   <meta name="twitter:title" content="Speedoodle Blog | Video Call Speed Insights" />
   <meta name="twitter:description" content="Guides on latency, jitter, and bandwidth for crystal-clear video meetings." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-LD6QWT7SJ0');
+  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Contact | Speedoodle 🚀</title>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+<script>
+window.dataLayer=window.dataLayer||[];
+function gtag(){dataLayer.push(arguments);}
+gtag('js',new Date());
+gtag('config','G-LD6QWT7SJ0');
+</script>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>

--- a/faq/index.html
+++ b/faq/index.html
@@ -15,6 +15,13 @@
   <meta name="twitter:title" content="Speedoodle FAQ | Video Call Speed Questions Answered" />
   <meta name="twitter:description" content="Understand the internet speed metrics that keep your video calls stable." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-LD6QWT7SJ0');
+  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,13 @@
   <meta name="twitter:title" content="Video Call Speed Test 🚀 | Speedoodle" />
   <meta name="twitter:description" content="Quick speed test tailored for Zoom, Google Meet, and Teams." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-LD6QWT7SJ0');
+  </script>
   <style>
     :root{ --bg:#0b1020; --panel:#171e2b; --border:#2b3546; --muted:#9aa6bd; --text:#e6edf6; --teal:#21d0c3; --good:#21d6c7; --warn:#f2c94c; --bad:#ff5470; }
     *{box-sizing:border-box}

--- a/privacy.html
+++ b/privacy.html
@@ -2,6 +2,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy | Speedoodle 🚀</title>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+<script>
+window.dataLayer=window.dataLayer||[];
+function gtag(){dataLayer.push(arguments);}
+gtag('js',new Date());
+gtag('config','G-LD6QWT7SJ0');
+</script>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>

--- a/terms.html
+++ b/terms.html
@@ -2,6 +2,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Terms of Use | Speedoodle 🚀</title>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+<script>
+window.dataLayer=window.dataLayer||[];
+function gtag(){dataLayer.push(arguments);}
+gtag('js',new Date());
+gtag('config','G-LD6QWT7SJ0');
+</script>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>


### PR DESCRIPTION
## Summary
- add the Google Analytics gtag loader and configuration to every static HTML page served to visitors
- ensure the analytics snippet is loaded before any other analytics scripts on those pages

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d912c354ec83238447b4fa11c7aec9