### PR TITLE
Add Google AdSense blocks to main pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,6 +14,15 @@ gtag('config','G-LD6QWT7SJ0');
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">
 <h1>About</h1>
+<div class="ad-wrapper">
+  <ins class="adsbygoogle"
+    style="display:block"
+    data-ad-client="ca-pub-8054613417167519"
+    data-ad-slot="YOUR_SLOT_ID"
+    data-ad-format="auto"
+    data-full-width-responsive="true"></ins>
+</div>
+<script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
 <p>Speedoodle is a lightweight internet speed test inspired by Fast.com—simple, fast, and friendly.</p>
 <ul>
   <li>Simplicity: clear download/upload/latency results.</li>

--- a/contact.html
+++ b/contact.html
@@ -14,6 +14,15 @@ gtag('config','G-LD6QWT7SJ0');
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">
 <h1>Contact</h1>
+<div class="ad-wrapper">
+  <ins class="adsbygoogle"
+    style="display:block"
+    data-ad-client="ca-pub-8054613417167519"
+    data-ad-slot="YOUR_SLOT_ID"
+    data-ad-format="auto"
+    data-full-width-responsive="true"></ins>
+</div>
+<script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
 <p>We’d love to hear from you.</p>
 <form action="mailto:hello@speedoodle.com" method="post" enctype="text/plain" class="card">
   <label>Full name<input name="name" required></label>

--- a/index.html
+++ b/index.html
@@ -122,6 +122,16 @@
       <p class="tagline">Speedoodle helps you check your internet quality for Zoom, Google Meet, and Microsoft Teams video calls.</p>
     </header>
 
+    <div class="ad-wrapper">
+      <ins class="adsbygoogle"
+        style="display:block"
+        data-ad-client="ca-pub-8054613417167519"
+        data-ad-slot="YOUR_SLOT_ID"
+        data-ad-format="auto"
+        data-full-width-responsive="true"></ins>
+    </div>
+    <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+
     <section class="tiles">
       <div class="tile"><h3>Download</h3><div id="dlVal" class="value">—</div><span class="unit">Mbps</span></div>
       <div class="tile"><h3>Upload</h3><div id="ulVal" class="value">—</div><span class="unit">Mbps</span><div class="unit" id="uplNote"></div></div>

--- a/site.css
+++ b/site.css
@@ -19,6 +19,8 @@ footer{font-size:.9rem}
 .stat-card .val{font-size:28px;font-weight:800}
 .testing .big-num,.testing .stat-card .val{animation:pulse 1.6s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.9;transform:scale(.992)}}
+.ad-wrapper{margin:24px 0;display:flex;justify-content:center}
+.ad-wrapper .adsbygoogle{width:100%}
 .adsbygoogle,#ad-slot-1{position:relative;z-index:1}
 #runTest{position:relative;z-index:2}
 /* === Animated Gauge + CountUp (safe append) === */


### PR DESCRIPTION
## Summary
- embed AdSense ad units and initialization scripts on the home, about, and contact pages
- add shared ad wrapper styling to control spacing and layout around the ad slots

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d917868de883238ca1168136829857