### PR TITLE
Add AdSense meta and script tags

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,6 +3,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>About | Speedoodle 🚀</title>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 <script>
 window.dataLayer=window.dataLayer||[];
 function gtag(){dataLayer.push(arguments);}

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Contact | Speedoodle 🚀</title>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 <script>
 window.dataLayer=window.dataLayer||[];
 function gtag(){dataLayer.push(arguments);}

--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
   <meta name="twitter:description" content="Quick speed test tailored for Zoom, Google Meet, and Teams." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+  <meta name="google-adsense-account" content="ca-pub-8054613417167519">
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}

--- a/privacy.html
+++ b/privacy.html
@@ -3,6 +3,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy | Speedoodle 🚀</title>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 <script>
 window.dataLayer=window.dataLayer||[];
 function gtag(){dataLayer.push(arguments);}

--- a/terms.html
+++ b/terms.html
@@ -3,6 +3,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Terms of Use | Speedoodle 🚀</title>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+<meta name="google-adsense-account" content="ca-pub-8054613417167519">
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
 <script>
 window.dataLayer=window.dataLayer||[];
 function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
## Summary
- add the Google AdSense account meta tag to each static HTML page
- load the AdSense script alongside the existing analytics snippet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d917807988832384d7ccef7b9b02da