### PR TITLE
Add rocket favicon across pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>About | Speedoodle 🚀</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
 <meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>

--- a/blog/index.html
+++ b/blog/index.html
@@ -6,6 +6,7 @@
   <title>Speedoodle Blog | Video Call Speed Insights</title>
   <meta name="description" content="Read Speedoodle's latest tips on internet performance for Zoom, Google Meet, and Teams video calls." />
   <link rel="canonical" href="https://www.speedoodle.com/blog/" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta property="og:title" content="Speedoodle Blog | Video Call Speed Insights" />
   <meta property="og:description" content="Guides on latency, jitter, and bandwidth for crystal-clear video meetings." />
   <meta property="og:type" content="website" />

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Contact | Speedoodle 🚀</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
 <meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>

--- a/faq/index.html
+++ b/faq/index.html
@@ -6,6 +6,7 @@
   <title>Speedoodle FAQ | Video Call Speed Questions Answered</title>
   <meta name="description" content="Get answers about latency, jitter, packet loss, and upload speeds for smooth video calls with Speedoodle." />
   <link rel="canonical" href="https://www.speedoodle.com/faq/" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta property="og:title" content="Speedoodle FAQ | Video Call Speed Questions Answered" />
   <meta property="og:description" content="Understand the internet speed metrics that keep your video calls stable." />
   <meta property="og:type" content="website" />

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="48">🚀</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Check if your internet is ready for Zoom, Google Meet, or Teams calls. Speedoodle 🚀 runs a quick speed test tailored for video conferencing stability." />
   <meta name="keywords" content="video call speed test, zoom speed test, google meet speed test, microsoft teams internet test, voip speed test, internet speed for video conferencing, online video call quality test" />
   <link rel="canonical" href="https://www.speedoodle.com/" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <meta property="og:title" content="Video Call Speed Test 🚀 | Speedoodle" />
   <meta property="og:description" content="Is your connection ready for video calls? Test your internet for Zoom, Google Meet, and Teams with Speedoodle." />
   <meta property="og:type" content="website" />

--- a/privacy.html
+++ b/privacy.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy | Speedoodle 🚀</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
 <meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>

--- a/terms.html
+++ b/terms.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Terms of Use | Speedoodle 🚀</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
 <meta name="google-adsense-account" content="ca-pub-8054613417167519">
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- add a reusable rocket emoji favicon asset for the site
- reference the favicon from all public HTML documents so the tab icon appears consistently

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68d97d0991c48323941a76bb34186d66