### PR TITLE
Update privacy policy contact email

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -35,7 +35,7 @@ gtag('config','G-LD6QWT7SJ0');
 <h2>Sharing</h2>
 <p>We do not sell personal data. We may share with infrastructure/analytics/ads providers under binding agreements.</p>
 <h2>Your rights</h2>
-<p>You can request access/deletion of data submitted via the form. Contact: <a href="mailto:hello@speedoodle.com">hello@speedoodle.com</a>.</p>
+<p>You can request access/deletion of data submitted via the form. Contact: <a href="mailto:privacy@speedoodle.com">privacy@speedoodle.com</a>.</p>
 <h2>Children</h2>
 <p>The site is intended for users aged 16+.</p>
 <h2>Security</h2>


### PR DESCRIPTION
## Summary
- update the privacy policy contact email to use the dedicated privacy@speedoodle.com address

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da56c7887c8323b94ba46be21acc4b