### PR TITLE
Remove unsupported search action from WebSite schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,12 +93,7 @@
     "@type":"WebSite",
     "name":"Speedoodle",
     "url":"https://www.speedoodle.com",
-    "description":"Video call speed test tailored for Zoom, Google Meet, and Teams.",
-    "potentialAction":{
-      "@type":"SearchAction",
-      "target":"https://www.speedoodle.com/?q={query}",
-      "query-input":"required name=query"
-    }
+    "description":"Video call speed test tailored for Zoom, Google Meet, and Teams."
   }
   </script>
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- remove the SearchAction potentialAction stanza from the WebSite JSON-LD since the site has no on-page search

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da5c3127c083238f72beb73f8bc9cb