### PR TITLE
Restore landing page and reapply SEO updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,20 +3,25 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Video Call Speed Test 🚀 | Speedoodle</title>
-  <meta name="description" content="Check if your internet is ready for Zoom, Google Meet, or Teams calls. Speedoodle 🚀 runs a quick speed test tailored for video conferencing stability." />
-  <meta name="keywords" content="video call speed test, zoom speed test, google meet speed test, microsoft teams internet test, voip speed test, internet speed for video conferencing, online video call quality test" />
+  <title>Speedoodle 🚀 Internet Speed Test — Fast, Accurate, Free</title>
+  <meta name="description" content="Run a fast and accurate internet speed test. Check download, upload, ping, and jitter. Tips to improve Wi-Fi and understand your results — all in one simple page." />
   <link rel="canonical" href="https://www.speedoodle.com/" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta name="language" content="en" />
+  <meta name="keywords" content="internet speed test, speed test, check internet speed, download speed, upload speed, ping test, jitter, wifi speed" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <meta property="og:title" content="Video Call Speed Test 🚀 | Speedoodle" />
-  <meta property="og:description" content="Is your connection ready for video calls? Test your internet for Zoom, Google Meet, and Teams with Speedoodle." />
+  <!-- Open Graph -->
+  <meta property="og:title" content="Speedoodle 🚀 Internet Speed Test" />
+  <meta property="og:description" content="Test your download, upload, ping, and jitter in seconds. Clear explanations and tips — all on one page." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://www.speedoodle.com/" />
-  <meta property="og:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <meta property="og:image" content="https://www.speedoodle.com/og-image.jpg" />
+  <meta property="og:site_name" content="Speedoodle" />
+  <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Video Call Speed Test 🚀 | Speedoodle" />
-  <meta name="twitter:description" content="Quick speed test tailored for Zoom, Google Meet, and Teams." />
-  <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <meta name="twitter:title" content="Speedoodle 🚀 Internet Speed Test" />
+  <meta name="twitter:description" content="Fast, accurate, free internet speed test with clear results and tips." />
+  <meta name="twitter:image" content="https://www.speedoodle.com/og-image.jpg" />
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
   <meta name="google-adsense-account" content="ca-pub-8054613417167519">
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
@@ -87,13 +92,15 @@
       .seo-section{padding:24px;margin:32px 0 16px}
     }
   </style>
+  <!-- Structured Data: Website -->
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",
     "@type":"WebSite",
     "name":"Speedoodle",
-    "url":"https://www.speedoodle.com",
-    "description":"Video call speed test tailored for Zoom, Google Meet, and Teams."
+    "url":"https://www.speedoodle.com/",
+    "inLanguage":"en",
+    "description":"Fast and accurate internet speed test for download, upload, ping, and jitter with clear explanations and improvement tips."
   }
   </script>
   <script type="application/ld+json">
@@ -107,22 +114,37 @@
     "offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}
   }
   </script>
+  <!-- Structured Data: FAQPage -->
   <script type="application/ld+json">
   {
     "@context":"https://schema.org",
     "@type":"FAQPage",
     "mainEntity":[
-      {"@type":"Question","name":"How often should I run the test?","acceptedAnswer":{"@type":"Answer","text":"We recommend weekly spot checks plus additional tests before major events. Testing at different times of day helps you detect congestion from neighbors or coworkers who share the same ISP infrastructure."}},
-      {"@type":"Question","name":"Can I use Speedoodle for non-video tasks?","acceptedAnswer":{"@type":"Answer","text":"Absolutely. The metrics we capture apply to gaming, cloud backups, and large data transfers. The verdict labels simply prioritize language that is easy to understand for video call troubleshooting."}},
-      {"@type":"Question","name":"Does the test store or sell my data?","acceptedAnswer":{"@type":"Answer","text":"No. All measurements happen directly in your browser. We do not require an account, and we do not share results with ISPs or advertisers. You remain in full control of your network diagnostics."}},
-      {"@type":"Question","name":"Why do results differ from other speed tests?","acceptedAnswer":{"@type":"Answer","text":"Different tools use distinct server locations, protocols, and sample sizes. Speedoodle emphasizes real-world video conferencing behavior, which may surface latency or jitter issues that generic tests miss."}},
-      {"@type":"Question","name":"What should I do if packet loss appears during the test?","acceptedAnswer":{"@type":"Answer","text":"Packet loss often points to overloaded routers or noisy Wi-Fi. Try switching to Ethernet, reducing the number of active devices, or consulting our packet loss troubleshooting guide for advanced fixes."}},
-      {"@type":"Question","name":"How can teams share these insights?","acceptedAnswer":{"@type":"Answer","text":"Use the CSV export and send a link to the hybrid teams latency article. Together they give IT managers a clear picture of which offices or remote employees need extra support."}},
-      {"@type":"Question","name":"Why is my internet slower than expected?","acceptedAnswer":{"@type":"Answer","text":"Common culprits include Wi-Fi interference, peak-time congestion, outdated hardware, or plan limits. Try Ethernet, move closer to the router, and restart your modem/router."}},
-      {"@type":"Question","name":"What is a good ping for gaming?","acceptedAnswer":{"@type":"Answer","text":"Under 50 ms is good; under 20 ms is excellent. Lower ping keeps gameplay responsive."}},
-      {"@type":"Question","name":"Why does upload speed matter?","acceptedAnswer":{"@type":"Answer","text":"Uploads power video calls, live streaming, cloud backups, and file sharing. Low upload speeds can cause choppy calls or stalled transfers."}},
-      {"@type":"Question","name":"How often should I test?","acceptedAnswer":{"@type":"Answer","text":"Test weekly and whenever you notice buffering or lag. Run tests at multiple times of day to identify congestion."}},
-      {"@type":"Question","name":"Does this test share data with my ISP?","acceptedAnswer":{"@type":"Answer","text":"No. Speedoodle runs entirely in your browser, and results are not shared with your provider."}}
+      {
+        "@type":"Question",
+        "name":"Is Speedoodle free?",
+        "acceptedAnswer":{"@type":"Answer","text":"Yes. Speedoodle is free to use and requires no registration."}
+      },
+      {
+        "@type":"Question",
+        "name":"How accurate are the results?",
+        "acceptedAnswer":{"@type":"Answer","text":"Results reflect real-world performance using reliable test servers. Variations can occur due to Wi-Fi signal, congestion, device, and routing."}
+      },
+      {
+        "@type":"Question",
+        "name":"Why is my speed lower than my provider’s plan?",
+        "acceptedAnswer":{"@type":"Answer","text":"Plans advertise “up to” speeds. Actual speeds depend on network congestion, modem/router quality, Wi-Fi interference, and distance from the router."}
+      },
+      {
+        "@type":"Question",
+        "name":"What speeds do I need for streaming and gaming?",
+        "acceptedAnswer":{"@type":"Answer","text":"HD streaming typically needs 5–10 Mbps download; 4K may need 25 Mbps+. For gaming, low ping (under ~30 ms) and low jitter matter more than raw download speed."}
+      },
+      {
+        "@type":"Question",
+        "name":"Do you store my test results or personal data?",
+        "acceptedAnswer":{"@type":"Answer","text":"Tests run locally in your browser. Privacy-friendly analytics may be used to improve the site. We do not sell personal information."}
+      }
     ]
   }
   </script>
@@ -131,7 +153,7 @@
   <div class="container">
     <header>
       <p class="brand">Speedoodle <span style="color:var(--teal)">🚀</span></p>
-      <h1>Video Call Speed Test</h1>
+      <h1>Internet Speed Test — Speedoodle 🚀</h1>
       <p class="tagline">Speedoodle helps you check your internet quality for Zoom, Google Meet, and Microsoft Teams video calls.</p>
     </header>
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.speedoodle.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.speedoodle.com/</loc>
+    <lastmod>2025-09-29</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- restore the landing page markup while inserting the requested SEO-focused title, description, robots, and social tags
- include the structured data blocks for the website and FAQ entries using the provided copy
- update the hero heading so the page keeps a single H1 with the requested text

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da6d31e8c883239a325894019946b4