### PR TITLE
Restore Speedoodle homepage and reapply safe SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,23 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Speedoodle 🚀 Internet Speed Test — Fast, Accurate, Free</title>
+  <meta name="description" content="Run a fast and accurate internet speed test. Check download, upload, ping, and jitter. Tips to improve Wi-Fi and understand your results — all in one simple page." />
+  <link rel="canonical" href="https://www.speedoodle.com/" />
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+  <meta name="language" content="en" />
+  <meta name="keywords" content="internet speed test, speed test, check internet speed, download speed, upload speed, ping test, jitter, wifi speed" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta property="og:title" content="Speedoodle 🚀 Internet Speed Test" />
+  <meta property="og:description" content="Test your download, upload, ping, and jitter in seconds. Clear explanations and tips — all on one page." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.speedoodle.com/" />
+  <meta property="og:image" content="https://www.speedoodle.com/og-image.jpg" />
+  <meta property="og:site_name" content="Speedoodle" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Speedoodle 🚀 Internet Speed Test" />
+  <meta name="twitter:description" content="Fast, accurate, free internet speed test with clear results and tips." />
+  <meta name="twitter:image" content="https://www.speedoodle.com/og-image.jpg" />
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
   <meta name="google-adsense-account" content="ca-pub-8054613417167519">
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
@@ -74,69 +90,41 @@
       .seo-section{padding:24px;margin:32px 0 16px}
     }
   </style>
-  <title>Speedoodle 🚀 Internet Speed Test — Fast, Accurate, Free</title>
-  <meta name="description" content="Run a fast and accurate internet speed test. Check download, upload, ping, and jitter. Tips to improve Wi-Fi and understand your results — all in one simple page." />
-  <link rel="canonical" href="https://www.speedoodle.com/" />
-  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
-  <meta name="language" content="en" />
-  <meta name="keywords" content="internet speed test, speed test, check internet speed, download speed, upload speed, ping test, jitter, wifi speed" />
-  <!-- Open Graph -->
-  <meta property="og:title" content="Speedoodle 🚀 Internet Speed Test" />
-  <meta property="og:description" content="Test your download, upload, ping, and jitter in seconds. Clear explanations and tips — all on one page." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.speedoodle.com/" />
-  <meta property="og:image" content="https://www.speedoodle.com/og-image.jpg" />
-  <meta property="og:site_name" content="Speedoodle" />
-  <!-- Twitter -->
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Speedoodle 🚀 Internet Speed Test" />
-  <meta name="twitter:description" content="Fast, accurate, free internet speed test with clear results and tips." />
-  <meta name="twitter:image" content="https://www.speedoodle.com/og-image.jpg" />
-  <!-- Structured Data: Website -->
-  <script type="application/ld+json">
-  {
-    "@context":"https://schema.org",
-    "@type":"WebSite",
-    "name":"Speedoodle",
-    "url":"https://www.speedoodle.com/",
-    "inLanguage":"en",
-    "description":"Fast and accurate internet speed test for download, upload, ping, and jitter with clear explanations and improvement tips."
-  }
-  </script>
-  <!-- Structured Data: FAQPage -->
-  <script type="application/ld+json">
-  {
-    "@context":"https://schema.org",
-    "@type":"FAQPage",
-    "mainEntity":[
-      {
-        "@type":"Question",
-        "name":"Is Speedoodle free?",
-        "acceptedAnswer":{"@type":"Answer","text":"Yes. Speedoodle is free to use and requires no registration."}
-      },
-      {
-        "@type":"Question",
-        "name":"How accurate are the results?",
-        "acceptedAnswer":{"@type":"Answer","text":"Results reflect real-world performance using reliable test servers. Variations can occur due to Wi-Fi signal, congestion, device, and routing."}
-      },
-      {
-        "@type":"Question",
-        "name":"Why is my speed lower than my provider’s plan?",
-        "acceptedAnswer":{"@type":"Answer","text":"Plans advertise “up to” speeds. Actual speeds depend on network congestion, modem/router quality, Wi-Fi interference, and distance from the router."}
-      },
-      {
-        "@type":"Question",
-        "name":"What speeds do I need for streaming and gaming?",
-        "acceptedAnswer":{"@type":"Answer","text":"HD streaming typically needs 5–10 Mbps download; 4K may need 25 Mbps+. For gaming, low ping (under ~30 ms) and low jitter matter more than raw download speed."}
-      },
-      {
-        "@type":"Question",
-        "name":"Do you store my test results or personal data?",
-        "acceptedAnswer":{"@type":"Answer","text":"Tests run locally in your browser. Privacy-friendly analytics may be used to improve the site. We do not sell personal information."}
-      }
-    ]
-  }
-  </script>
+  <script type="application/ld+json">{
+  "@context":"https://schema.org",
+  "@type":"WebSite",
+  "name":"Speedoodle",
+  "url":"https://www.speedoodle.com/",
+  "inLanguage":"en",
+  "description":"Fast and accurate internet speed test for download, upload, ping, and jitter with clear explanations and improvement tips."
+}</script>
+
+  <script type="application/ld+json">{
+  "@context":"https://schema.org",
+  "@type":"FAQPage",
+  "mainEntity":[
+    {"@type":"Question","name":"Is Speedoodle free?","acceptedAnswer":{"@type":"Answer","text":"Yes. Speedoodle is free to use and requires no registration."}},
+    {"@type":"Question","name":"How accurate are the results?","acceptedAnswer":{"@type":"Answer","text":"Results reflect real-world performance using reliable test servers. Variations can occur due to Wi-Fi signal, congestion, device, and routing."}},
+    {"@type":"Question","name":"Why is my speed lower than my provider’s plan?","acceptedAnswer":{"@type":"Answer","text":"Plans advertise “up to” speeds. Actual speeds depend on network congestion, modem/router quality, Wi-Fi interference, and distance from the router."}},
+    {"@type":"Question","name":"What speeds do I need for streaming and gaming?","acceptedAnswer":{"@type":"Answer","text":"HD streaming typically needs 5–10 Mbps; 4K may need 25 Mbps+. For gaming, low ping (~<30 ms) and low jitter matter more than raw download speed."}},
+    {"@type":"Question","name":"Do you store my test results or personal data?","acceptedAnswer":{"@type":"Answer","text":"Tests run locally in your browser. Privacy-friendly analytics may be used to improve the site. We do not sell personal information."}}
+  ]
+}</script>
+
+  <script type="application/ld+json">{
+  "@context":"https://schema.org",
+  "@type":"Organization",
+  "name":"Speedoodle",
+  "url":"https://www.speedoodle.com/",
+  "logo":"https://www.speedoodle.com/logo.png",
+  "contactPoint":[{"@type":"ContactPoint","email":"hello@speedoodle.com","contactType":"customer support","availableLanguage":["en"]}]
+}</script>
+
+  <script type="application/ld+json">{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.speedoodle.com/"}]
+}</script>
 </head>
 <body>
   <div class="container">


### PR DESCRIPTION
## Summary
- restore the homepage markup to the last stable layout so the existing speed test scripts work again
- update the head with the requested safe SEO tags, Open Graph/Twitter metadata, and structured data
- ensure the page keeps a single descriptive H1 matching the restored content

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68da8542a2a88323ba9cef8544475daf