### PR TITLE
Add AdSense snippet to blog pages and app layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"
           strategy="afterInteractive"
         />
+        <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
+        <Script
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
+          strategy="afterInteractive"
+          crossOrigin="anonymous"
+        />
         <Script id="google-analytics" strategy="afterInteractive">
           {`
             window.dataLayer = window.dataLayer || [];

--- a/blog/how-much-bandwidth-zoom.html
+++ b/blog/how-much-bandwidth-zoom.html
@@ -16,6 +16,21 @@
   <meta name="twitter:title" content="How Much Bandwidth Do I Need for Zoom?" />
   <meta name="twitter:description" content="Understand Zoom's download, upload, and latency needs and learn how to meet them." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
+  <script
+    async
+    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
+    crossorigin="anonymous"
+  ></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag("js", new Date());
+    gtag("config", "G-LD6QWT7SJ0");
+  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/blog/index.html
+++ b/blog/index.html
@@ -17,6 +17,12 @@
   <meta name="twitter:description" content="Guides on latency, jitter, and bandwidth for crystal-clear video meetings." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
+  <script
+    async
+    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
+    crossorigin="anonymous"
+  ></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}

--- a/blog/lowering-latency-hybrid-teams.html
+++ b/blog/lowering-latency-hybrid-teams.html
@@ -16,6 +16,21 @@
   <meta name="twitter:title" content="Lowering Latency for Hybrid Teams" />
   <meta name="twitter:description" content="Use Speedoodle insights to keep distributed teams connected with low latency." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
+  <script
+    async
+    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
+    crossorigin="anonymous"
+  ></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag("js", new Date());
+    gtag("config", "G-LD6QWT7SJ0");
+  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/blog/understanding-packet-loss-video-meetings.html
+++ b/blog/understanding-packet-loss-video-meetings.html
@@ -16,6 +16,21 @@
   <meta name="twitter:title" content="Understanding Packet Loss in Video Meetings" />
   <meta name="twitter:description" content="Decode Speedoodle metrics and eliminate packet loss from your calls." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
+  <script
+    async
+    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
+    crossorigin="anonymous"
+  ></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag("js", new Date());
+    gtag("config", "G-LD6QWT7SJ0");
+  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add the AdSense account meta tag and loader script to the Next.js root layout so all app routes load the publisher code
- inject the same AdSense snippet on each blog page to align with the static site pages

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68df9c101d6c8323974e9ae5c9e04d09