### PR TITLE
Add AdSense script to FAQ page

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -17,6 +17,12 @@
   <meta name="twitter:description" content="Understand the internet speed metrics that keep your video calls stable." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
+  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
+  <script
+    async
+    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
+    crossorigin="anonymous"
+  ></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
## Summary
- add the Google AdSense account meta tag and script to the FAQ page head so ads load there too

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa27f4304832398ddc08be0f096f0