### PR TITLE
Remove Google tracking and ad integrations

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,29 +3,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>About | Speedoodle 🚀</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-<meta name="google-adsense-account" content="ca-pub-8054613417167519">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
-<script>
-window.dataLayer=window.dataLayer||[];
-function gtag(){dataLayer.push(arguments);}
-gtag('js',new Date());
-gtag('config','G-LD6QWT7SJ0');
-</script>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">
 <h1>About</h1>
-<div class="ad-wrapper">
-  <ins class="adsbygoogle"
-    style="display:block"
-    data-ad-client="ca-pub-8054613417167519"
-    data-ad-slot="YOUR_SLOT_ID"
-    data-ad-format="auto"
-    data-full-width-responsive="true"></ins>
-</div>
-<script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
 <p>Speedoodle is a lightweight internet speed test inspired by Fast.com—simple, fast, and friendly.</p>
 <ul>
   <li>Simplicity: clear download/upload/latency results.</li>

--- a/ads.txt
+++ b/ads.txt
@@ -1,1 +1,0 @@
-google.com, pub-8054613417167519, DIRECT, f08c47fec0942fa0

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -10,27 +9,6 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <head>
-        {/* Google Analytics */}
-        <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"
-          strategy="afterInteractive"
-        />
-        <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
-        <Script
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
-          strategy="afterInteractive"
-          crossOrigin="anonymous"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'G-LD6QWT7SJ0');
-          `}
-        </Script>
-      </head>
       <body>{children}</body>
     </html>
   );

--- a/blog/how-much-bandwidth-zoom.html
+++ b/blog/how-much-bandwidth-zoom.html
@@ -16,21 +16,6 @@
   <meta name="twitter:title" content="How Much Bandwidth Do I Need for Zoom?" />
   <meta name="twitter:description" content="Understand Zoom's download, upload, and latency needs and learn how to meet them." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
-  <script
-    async
-    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
-    crossorigin="anonymous"
-  ></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-    gtag("config", "G-LD6QWT7SJ0");
-  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/blog/index.html
+++ b/blog/index.html
@@ -16,19 +16,6 @@
   <meta name="twitter:title" content="Speedoodle Blog | Video Call Speed Insights" />
   <meta name="twitter:description" content="Guides on latency, jitter, and bandwidth for crystal-clear video meetings." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
-  <script
-    async
-    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
-    crossorigin="anonymous"
-  ></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-LD6QWT7SJ0');
-  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/blog/lowering-latency-hybrid-teams.html
+++ b/blog/lowering-latency-hybrid-teams.html
@@ -16,21 +16,6 @@
   <meta name="twitter:title" content="Lowering Latency for Hybrid Teams" />
   <meta name="twitter:description" content="Use Speedoodle insights to keep distributed teams connected with low latency." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
-  <script
-    async
-    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
-    crossorigin="anonymous"
-  ></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-    gtag("config", "G-LD6QWT7SJ0");
-  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/blog/understanding-packet-loss-video-meetings.html
+++ b/blog/understanding-packet-loss-video-meetings.html
@@ -16,21 +16,6 @@
   <meta name="twitter:title" content="Understanding Packet Loss in Video Meetings" />
   <meta name="twitter:description" content="Decode Speedoodle metrics and eliminate packet loss from your calls." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
-  <script
-    async
-    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
-    crossorigin="anonymous"
-  ></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag("js", new Date());
-    gtag("config", "G-LD6QWT7SJ0");
-  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/contact.html
+++ b/contact.html
@@ -3,29 +3,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Contact | Speedoodle 🚀</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-<meta name="google-adsense-account" content="ca-pub-8054613417167519">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
-<script>
-window.dataLayer=window.dataLayer||[];
-function gtag(){dataLayer.push(arguments);}
-gtag('js',new Date());
-gtag('config','G-LD6QWT7SJ0');
-</script>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>
 <main class="container">
 <h1>Contact</h1>
-<div class="ad-wrapper">
-  <ins class="adsbygoogle"
-    style="display:block"
-    data-ad-client="ca-pub-8054613417167519"
-    data-ad-slot="YOUR_SLOT_ID"
-    data-ad-format="auto"
-    data-full-width-responsive="true"></ins>
-</div>
-<script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
 <p>We’d love to hear from you.</p>
 <form action="mailto:hello@speedoodle.com" method="post" enctype="text/plain" class="card">
   <label>Full name<input name="name" required></label>

--- a/faq.html
+++ b/faq.html
@@ -16,19 +16,6 @@
   <meta name="twitter:title" content="Speedoodle FAQ | Video Call Speed Questions Answered" />
   <meta name="twitter:description" content="Understand the internet speed metrics that keep your video calls stable." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
-  <script
-    async
-    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
-    crossorigin="anonymous"
-  ></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-LD6QWT7SJ0');
-  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/faq/index.html
+++ b/faq/index.html
@@ -16,19 +16,6 @@
   <meta name="twitter:title" content="Speedoodle FAQ | Video Call Speed Questions Answered" />
   <meta name="twitter:description" content="Understand the internet speed metrics that keep your video calls stable." />
   <meta name="twitter:image" content="https://www.speedoodle.com/thumbnail.png" />
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-  <meta name="google-adsense-account" content="ca-pub-8054613417167519" />
-  <script
-    async
-    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519"
-    crossorigin="anonymous"
-  ></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-LD6QWT7SJ0');
-  </script>
   <link rel="stylesheet" href="/site.css" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -20,16 +20,7 @@
   <meta name="twitter:title" content="Speedoodle 🚀 Internet Speed Test" />
   <meta name="twitter:description" content="Fast, accurate, free internet speed test with clear results and tips." />
   <meta name="twitter:image" content="https://www.speedoodle.com/og-image.jpg" />
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-  <meta name="google-adsense-account" content="ca-pub-8054613417167519">
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-LD6QWT7SJ0');
-  </script>
-  <style>
+<style>
     :root{ --bg:#0b1020; --panel:#171e2b; --border:#2b3546; --muted:#9aa6bd; --text:#e6edf6; --teal:#21d0c3; --good:#21d6c7; --warn:#f2c94c; --bad:#ff5470; }
     *{box-sizing:border-box}
     html,body{height:100%}
@@ -202,16 +193,7 @@
 
     <section class="seo-section" id="how-it-works">
       <h2>How the Speedoodle Video Call Speed Test Works</h2>
-      <div class="ad-wrapper">
-        <ins class="adsbygoogle"
-          style="display:block"
-          data-ad-client="ca-pub-8054613417167519"
-          data-ad-slot="1234567890"
-          data-ad-format="fluid"
-          data-full-width-responsive="true"></ins>
-      </div>
-      <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
-      <p>
+<p>
         Speedoodle 🚀 was designed as a practical toolkit for anyone who relies on live video. When you press
         the green <strong>GO</strong> button our test opens multiple secure connections to strategically chosen
         edge servers. The browser downloads and uploads randomized data blocks that simulate a real Zoom or
@@ -281,18 +263,7 @@
         <a href="/blog/">Speedoodle blog</a> for in-depth tutorials on QoS rules, packet loss, and remote team setups.
       </p>
     </section>
-
-    <div class="ad-wrapper">
-      <ins class="adsbygoogle"
-        style="display:block"
-        data-ad-client="ca-pub-8054613417167519"
-        data-ad-slot="2345678901"
-        data-ad-format="fluid"
-        data-full-width-responsive="true"></ins>
-    </div>
-    <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
-
-    <section class="seo-section" id="recommended-speeds">
+<section class="seo-section" id="recommended-speeds">
       <h2>Recommended Internet Speeds for Video Platforms</h2>
       <p>
         Use the table below as a benchmark for common call scenarios. The targets blend official recommendations
@@ -318,18 +289,7 @@
         to conference rooms to isolate mission-critical meetings from guest Wi-Fi traffic.
       </p>
     </section>
-
-    <div class="ad-wrapper">
-      <ins class="adsbygoogle"
-        style="display:block"
-        data-ad-client="ca-pub-8054613417167519"
-        data-ad-slot="3456789012"
-        data-ad-format="autorelaxed"
-        data-full-width-responsive="true"></ins>
-    </div>
-    <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
-
-    <section class="seo-section" id="video-faq">
+<section class="seo-section" id="video-faq">
       <h2>Video Call Speed Test FAQs</h2>
       <details>
         <summary><strong>How often should I run the test?</strong></summary>

--- a/privacy.html
+++ b/privacy.html
@@ -3,15 +3,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy | Speedoodle 🚀</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-<meta name="google-adsense-account" content="ca-pub-8054613417167519">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
-<script>
-window.dataLayer=window.dataLayer||[];
-function gtag(){dataLayer.push(arguments);}
-gtag('js',new Date());
-gtag('config','G-LD6QWT7SJ0');
-</script>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>

--- a/site.css
+++ b/site.css
@@ -19,10 +19,6 @@ footer{font-size:.9rem}
 .stat-card .val{font-size:28px;font-weight:800}
 .testing .big-num,.testing .stat-card .val{animation:pulse 1.6s ease-in-out infinite}
 @keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.9;transform:scale(.992)}}
-.ad-wrapper{margin:24px 0;display:flex;justify-content:center}
-.ad-wrapper .adsbygoogle{width:100%}
-.adsbygoogle,#ad-slot-1{position:relative;z-index:1}
-#runTest{position:relative;z-index:2}
 /* === Animated Gauge + CountUp (safe append) === */
 :root{--muted:#94a3b8;--accent:#2563eb}
 .gauge-wrap{display:grid;place-items:center;margin:18px auto}

--- a/terms.html
+++ b/terms.html
@@ -3,15 +3,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Terms of Use | Speedoodle 🚀</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-LD6QWT7SJ0"></script>
-<meta name="google-adsense-account" content="ca-pub-8054613417167519">
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8054613417167519" crossorigin="anonymous"></script>
-<script>
-window.dataLayer=window.dataLayer||[];
-function gtag(){dataLayer.push(arguments);}
-gtag('js',new Date());
-gtag('config','G-LD6QWT7SJ0');
-</script>
 <link rel="stylesheet" href="site.css">
 </head><body>
 <header><a href="./">Speedoodle 🚀</a></header>


### PR DESCRIPTION
## Summary
- remove Google Tag Manager / AdSense scripts from the Next.js layout and static HTML pages
- strip ad slot markup and related styles, including deleting ads.txt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb1b78f5083239d47a5702f714e43